### PR TITLE
feat: Add Get-LastMetasysHeadersAsObject

### DIFF
--- a/Invoke-MetasysMethod/Invoke-MetasysMethod.psd1
+++ b/Invoke-MetasysMethod/Invoke-MetasysMethod.psd1
@@ -73,7 +73,8 @@
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = 'Invoke-MetasysMethod', 'Show-LastMetasysHeaders', 'Show-LastMetasysAccessToken', 'Show-LastMetasysResponseBody', 'Show-LastMetasysFullResponse',
-        'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus', "Get-MetasysUsers", "Get-MetasysPassword", "Remove-MetasysPassword", "Set-MetasysPassword"
+        'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus', "Get-MetasysUsers", "Get-MetasysPassword", "Remove-MetasysPassword", "Set-MetasysPassword",
+        'Get-LastMetasysHeadersAsObject'
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport      = @()

--- a/Invoke-MetasysMethod/Invoke-MetasysMethod.psm1
+++ b/Invoke-MetasysMethod/Invoke-MetasysMethod.psm1
@@ -359,7 +359,11 @@ function Get-LastMetasysResponseBodyAsObject {
     return ConvertFrom-JsonSafely ([MetasysEnvVars]::getLast())
 }
 
+function Get-LastMetasysHeadersAsObject {
+    return ConvertFrom-Json ([MetasysEnvVars]::getHeaders())
+}
 
 
-Export-ModuleMember -Function 'Invoke-MetasysMethod', 'Show-LastMetasysHeaders', 'Show-LastMetasysAccessToken', 'Show-LastMetasysResponseBody', 'Show-LastMetasysFullResponse', 'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus'
+
+Export-ModuleMember -Function 'Invoke-MetasysMethod', 'Show-LastMetasysHeaders', 'Show-LastMetasysAccessToken', 'Show-LastMetasysResponseBody', 'Show-LastMetasysFullResponse', 'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus', 'Get-LastMetasysHeadersAsObject'
 


### PR DESCRIPTION
If you want to programmatically query the headers it is helpful
for them to be in an object vs. json. This convenience function
does that.