### PR TITLE
feat: add support for 204 response

### DIFF
--- a/Invoke-MetasysMethod/Invoke-MetasysMethod.psm1
+++ b/Invoke-MetasysMethod/Invoke-MetasysMethod.psm1
@@ -278,7 +278,7 @@ function Invoke-MetasysMethod {
             }
             else {
                 if ($responseObject) {
-                    if (($responseObject.Headers["Content-Length"] -eq "0") -or ($responseObject.Headers["Content-Type"] -like "*json*")) {
+                    if (($responseObject.Headers["Content-Length"] -eq "0") -or ($responseObject.Headers["Content-Type"] -like "*json*") -or ($responseObject.StatusCode -eq 204)) {
                         $response = [String]::new($responseObject.Content)
                     }
                     else {


### PR DESCRIPTION
The previous response processing assumed that one of two
things were true on a response:

* Content-Type is json
* Content-Length is 0

But on a 204 response (like after deleting an object) there is no
content so neither of the previous is true. So the response
handling would report an error. This case is now handled.