### PR TITLE
fix: remove use of exit in functions

### DIFF
--- a/Invoke-MetasysMethod.ps1
+++ b/Invoke-MetasysMethod.ps1
@@ -6,7 +6,6 @@ param(
     [switch]$Login,
     [Parameter(Position=0)]
     [string]$Path,
-    [switch]$Clear,
     [string]$Body,
     [Microsoft.PowerShell.Commands.WebRequestMethod]$Method = "Get",
     [Int]$Version,
@@ -22,4 +21,4 @@ Import-Module -Force -Name ./Invoke-MetasysMethod
 # mget-object "WIN-21DJ9JV9QH6:EECMI-NCE25-2/MV1" -SkipCertificateCheck:$SkipCertificateCheck
 Invoke-MetasysMethod -SiteHost $SiteHost -UserName $UserName -Path $Path -Body $Body `
     -Method $Method -Version $Version -SkipCertificateCheck:$SkipCertificateCheck `
-    -Clear:$Clear -Login:$Login -Header $Headers -Password $Password
+    -Login:$Login -Header $Headers -Password $Password

--- a/Invoke-MetasysMethod/Invoke-MetasysMethod.psd1
+++ b/Invoke-MetasysMethod/Invoke-MetasysMethod.psd1
@@ -74,7 +74,7 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = 'Invoke-MetasysMethod', 'Show-LastMetasysHeaders', 'Show-LastMetasysAccessToken', 'Show-LastMetasysResponseBody', 'Show-LastMetasysFullResponse',
         'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus', "Get-MetasysUsers", "Get-MetasysPassword", "Remove-MetasysPassword", "Set-MetasysPassword",
-        'Get-LastMetasysHeadersAsObject'
+        'Get-LastMetasysHeadersAsObject', 'Clear-MetasysEnvVariables'
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport      = @()


### PR DESCRIPTION
I thought this was an appropriate way to exit a function, but
it also exists the PowerShell ISE as well which is not desirable.

Fix #12

All usages of `exit` have been removed

* One instance was replaced with `throw`
* One intance was resolved by removing the function and using
  `ValidateRange` attribute on Version parameter
* One instance was replaced by deleting the `Clear` switch and
  replacing its functionality with a new function
  `Clear-MetaysEnvVariables`
* One instance was removed because the code in that location was in
  a catch block and it was doing what would have happened if there
  wasn't a try/catch block at all. Removed try/catch block