### PR TITLE
fix: correct output and return types of functions

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -1,5 +1,14 @@
 # This is local sanity check test script.
 
 
+$response = Invoke-MetasysMethod /enumerations -SiteHost welchoas
 
-Invoke-MetasysMethod -Login -SiteHost 10.164.104.81 -UserName testuser
+if ($response -isnot [String]) {
+    Write-Error "Expected response to be a stringt not $($response.GetType())"
+}
+
+$response = Invoke-MetasysMethod /enumerations -SiteHost welchoas -ReturnBodyAsObject
+
+if ($response -isnot [PSCustomObject] -and $response -isnot [Hashtable]) {
+    Write-Error "Expected resposne as object to be PSCustomObject or Hashtable, not $($response.GetType()))"
+}


### PR DESCRIPTION
Fix #15

I didn't understand the output stream and what ends up in the output
stream. My use of `Write-Output` was a leading cause in ensuring that
`Invoke-MetasysModule` and other functions return an array of objects
rather than a `String`, `PSCustomObject` or `Hashtable` which is the
normal expected response.

This commit removes all uses of Write-Output. This is done by

* Ensuring each happy path thru a function emits just one object
  (string in most but not all cases) to the output stream.
* Using Write-Error for some cases related to errors
* Using Write-Information for some cases