### PR TITLE
fix: make encodings explicit in sending and receiving

### DIFF
--- a/Invoke-MetasysMethod/Invoke-MetasysMethod.psm1
+++ b/Invoke-MetasysMethod/Invoke-MetasysMethod.psm1
@@ -252,7 +252,7 @@ function Invoke-MetasysMethod {
         else {
             if ($responseObject) {
                 if (($responseObject.Headers["Content-Length"] -eq "0") -or ($responseObject.Headers["Content-Type"] -like "*json*") -or ($responseObject.StatusCode -eq 204)) {
-                    $response = [String]::new($responseObject.Content)
+                    $response = [System.Text.Encoding]::UTF8.GetString($responseObject.Content)
                 }
                 else {
                     Write-Error "An unexpected content type was found"

--- a/Invoke-MetasysMethod/build-request.ps1
+++ b/Invoke-MetasysMethod/build-request.ps1
@@ -19,7 +19,7 @@ function buildRequest {
         Uri                  = $uri ?? (buildUri -path $Path -version $version)
         Body                 = $body
         SkipCertificateCheck = $skipCertificateCheck
-        ContentType          = "application/json"
+        ContentType          = "application/json; charset=utf-8"
         Headers              = @{}
     }
 


### PR DESCRIPTION
I discovered that I could not transfer Japanese characters via this
script. It turns out that I need to explicitly specify `utf8`
as the charset when sending data, and must explicitly use a UTF8
encoding do convert the payload into a String.