### PR TITLE
chore: udpate URLs to point to jci-metasys org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,22 +130,22 @@ No changes since alpha 3
   `Set-SavedMetasysPassword`
 
 [unreleased]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v2.3.0-rc1...HEAD
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v2.3.0-rc1...HEAD
 [2.3.0-rc1]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v2.2.0...v2.3.0-rc1
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v2.2.0...v2.3.0-rc1
 [2.2.0]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v2.1.2...v2.2.0
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v2.1.2...v2.2.0
 [2.1.2]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v2.1.0...v2.1.2
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v2.1.0...v2.1.2
 [2.1.0]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v2.0.0...v2.1.0
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v2.0.0...v2.1.0
 [2.0.0]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v1.0.0...v2.0.0
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v1.0.0...v2.0.0
 [1.0.0]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v1.0.0-alpha3...v1.0.0
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v1.0.0-alpha3...v1.0.0
 [1.0.0-alpha3]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v1.0.0-alpha2...v1.0.0-alpha3
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v1.0.0-alpha2...v1.0.0-alpha3
 [1.0.0-alpha2]:
-  https://github.com/metasys-server/powershell-metasysrestclient/compare/v1.0.0-alpha1...v1.0.0-alpha2
+  https://github.com/jci-metasys/powershell-metasysrestclient/compare/v1.0.0-alpha1...v1.0.0-alpha2
 [1.0.0-alpha1]:
-  https://github.com/metasys-server/powershell-metasysrestclient/releases/tag/v1.0.0-alpha1
+  https://github.com/jci-metasys/powershell-metasysrestclient/releases/tag/v1.0.0-alpha1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetasysRestClient
 
-[![Unit Tests](https://github.com/jci-metasys/powershell-metasysrestclient/actions/workflows/test.yml/badge.svg)](https://github.com/metasys-server/powershell-metasysrestclient/actions/workflows/test.yml)
+[![Unit Tests](https://github.com/jci-metasys/powershell-metasysrestclient/actions/workflows/test.yml/badge.svg)](https://github.com/jci-metasys/powershell-metasysrestclient/actions/workflows/test.yml)
 
 A PowerShell module that sends HTTPS request to a Metasys device running Metasys
 REST API.

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -108,7 +108,7 @@ function Invoke-MetasysMethod {
 
     .LINK
 
-        https://github.com/metasys-server/powershell-metasysrestclient
+        https://github.com/jci-metasys/powershell-metasysrestclient
 
     #>
 

--- a/src/MetasysRestClient/MetasysRestClient.psd1
+++ b/src/MetasysRestClient/MetasysRestClient.psd1
@@ -102,10 +102,10 @@
             # Tags = @()
 
             # A URL to the license for this module.
-            LicenseUri = 'https://github.com/metasys-server/powershell-metasysrestclient/blob/master/LICENSE'
+            LicenseUri = 'https://github.com/jci-metasys/powershell-metasysrestclient/blob/master/LICENSE'
 
             # A URL to the main website for this project.
-            ProjectUri = 'https://github.com/metasys-server/powershell-metasysrestclient'
+            ProjectUri = 'https://github.com/jci-metasys/powershell-metasysrestclient'
 
             # A URL to an icon representing this module.
             # IconUri = ''

--- a/src/MetasysRestClient/about_MetasysRestClient.help.txt
+++ b/src/MetasysRestClient/about_MetasysRestClient.help.txt
@@ -14,6 +14,6 @@ RELATED LINKS
 
     Connect-MetasysAccount
     Invoke-MetasysMethod
-    Metasys Rest Client Secret Management: https://github.com/metasys-server/powershell-metasysrestclient/blob/main/docs/secret-management.md
-    Tips for Working with Powershell: https://github.com/metasys-server/powershell-metasysrestclient/blob/main/docs/tips.md
+    Metasys Rest Client Secret Management: https://github.com/jci-metasys/powershell-metasysrestclient/blob/main/docs/secret-management.md
+    Tips for Working with Powershell: https://github.com/jci-metasys/powershell-metasysrestclient/blob/main/docs/tips.md
 


### PR DESCRIPTION
This repo moved from the org `metasys-server` to the org `jci-metasys` therefore many of the links in the documents were incorrect.