### PR TITLE
fix: use IsNullOrEmpty for $Version checks to handle omitted parameter

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -393,6 +393,30 @@ Describe "Connect-Metasys" -Tag "Unit" {
             }
         }
 
+        Context "When -Version parameter is omitted (null, not empty string)" {
+            BeforeAll {
+                Mock Invoke-RestMethod -ModuleName MetasysRestClient {
+                    CreateLoginResponse
+                }
+                Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient
+
+                # Omit -Version entirely so $Version is $null, not ""
+                Connect-MetasysAccount -MetasysHost "testhost" -UserName "user" `
+                    -Password ("pass" | ConvertTo-SecureString -AsPlainText -Force)
+            }
+
+            It "Should use the latest version in the URI" {
+                Should -Invoke Invoke-RestMethod -ModuleName MetasysRestClient -ParameterFilter {
+                    $Uri.ToString() -eq "https://testhost/api/v$LatestVersion/login"
+                } -Times 1 -Exactly -Scope Context
+            }
+
+            It 'Should set $env:METASYS_VERSION to the latest version (not null or empty)' {
+                $env:METASYS_VERSION | Should -Not -BeNullOrEmpty
+                $env:METASYS_VERSION | Should -Be $LatestVersion
+            }
+        }
+
     }
 
     Describe "Error Processing" {

--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -206,7 +206,7 @@ function Connect-MetasysAccount {
             $Password = (Get-SavedMetasysPassword -SiteHost $MetasysHost -UserName $UserName) ?? (Read-Host -Prompt "Password" -AsSecureString)
         }
 
-        if ($Version -eq "") {
+        if ([string]::IsNullOrEmpty($Version)) {
             $Version = (Get-MetasysDefaultApiVersion) ?? (Get-MetasysLatestVersion)
             Write-Information "No version specified. Defaulting to v$Version"
         }

--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -179,6 +179,24 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
 
         }
 
+        Context "When -Version is omitted (null) and METASYS_VERSION env var is set" {
+            BeforeAll {
+                $env:METASYS_VERSION = "4"
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient
+                Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient
+
+                # Omit -Version entirely so $Version is $null, not ""
+                Invoke-MetasysMethod /objects
+            }
+
+            It "Should use the saved version from METASYS_VERSION env var in the URI" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $Uri.ToString() -eq "https://$($env:METASYS_HOST)/api/v4/objects"
+                } -Exactly -Times 1 -Scope Context
+            }
+        }
+
 
     }
 
@@ -395,4 +413,35 @@ Header2: Header 2
         }
     }
 
+}
+
+Describe 'Get-MetasysLatestVersion' -Tag Unit {
+    It 'Should return version 6' {
+        Get-MetasysLatestVersion | Should -Be "6"
+    }
+}
+
+Describe 'Set-MetasysAccessToken' -Tag Unit {
+    AfterEach { Clear-MetasysEnvVariables }
+
+    It 'Should default to API version 6 when -Version is not specified' {
+        Set-MetasysAccessToken -AccessToken "mytoken" -MetasysHost "myhost" -Expires ([DateTimeOffset]::MaxValue)
+        $env:METASYS_VERSION | Should -Be "6"
+    }
+
+    It 'Should use specified version when -Version is provided' {
+        Set-MetasysAccessToken -AccessToken "mytoken" -MetasysHost "myhost" -Expires ([DateTimeOffset]::MaxValue) -Version "4"
+        $env:METASYS_VERSION | Should -Be "4"
+    }
+}
+
+Describe 'Module manifest' -Tag Unit {
+    It 'Should not export Set-MetasysSkipSecureCheckNotSecure' {
+        $commands = Get-Command -Module MetasysRestClient
+        $commands.Name | Should -Not -Contain 'Set-MetasysSkipSecureCheckNotSecure'
+    }
+    It 'Should not export Reset-MetasysSkipSecureCheckNotSecure' {
+        $commands = Get-Command -Module MetasysRestClient
+        $commands.Name | Should -Not -Contain 'Reset-MetasysSkipSecureCheckNotSecure'
+    }
 }

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -183,13 +183,13 @@ function Invoke-MetasysMethod {
         if ($uri.IsAbsoluteUri) {
             $versionSegment = $uri.Segments[2]
             $versionNumber = $versionSegment.SubString(1, $versionSegment.Length - 2)
-            if ($Version -ne "" -and $versionNumber -ne $Version) {
+            if (-not [string]::IsNullOrEmpty($Version) -and $versionNumber -ne $Version) {
                 Write-Error "An absolute url was given for Path and it specifies a version ('$versionNumber') that conflicts with Version ('$Version')"
                 continue
             }
         }
 
-        If ($Version -eq "") {
+        If ([string]::IsNullOrEmpty($Version)) {
             # Use the version from last cma call, else the default api version (if set), else latest version
             $Version = $env:METASYS_VERSION ?? (Get-MetasysDefaultApiVersion) ?? (Get-MetasysLatestVersion)
             Write-Information "No version specified. Defaulting to v$Version"


### PR DESCRIPTION
## Summary

When a `[string]$Version` parameter is omitted by the caller, PowerShell sets it to `$null`, not `""`. The existing `$Version -eq ""` checks silently never fired, meaning:
- Version defaulting was skipped → broken URLs like `.../api/v/login`
- Absolute-URL conflict check fired incorrectly when no version was supplied

## Changes
- `Invoke-MetasysMethod.psm1`: replaced `-eq ""` / `-ne ""` with `[string]::IsNullOrEmpty()`
- `Connect-MetasysAccount.ps1`: same fix for the version-defaulting block

Addresses comments from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).