### PR TITLE
fix: make SSE event parser robust to non-JSON data and fix id null-char check

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -189,7 +189,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
 
                 $script:metasysHost = "aHost"
                 $script:userName = "aUser"
-                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText
+                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText -Force
 
                 # qualify with $script to avoid unused-vars warnings from PSScriptAnalyzer
                 $script:response = Connect-MetasysAccount -MetasysHost $script:metasysHost `
@@ -246,13 +246,15 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Get-Content -ModuleName MetasysRestClient {
                     @"
                     {
-                        "hosts": {
-                            "alias": "host",
-                            "hostname": "$($script:metasysHost)",
-                            "username": "$($script:username)",
-                            "version": "$($script:version)",
-                            "skip-certificate-check": true
-                        }
+                        "hosts": [
+                            {
+                                "alias": "host",
+                                "hostname": "$($script:metasysHost)",
+                                "username": "$($script:username)",
+                                "version": "$($script:version)",
+                                "skip-certificate-check": true
+                            }
+                        ]
                     }
 "@
                 }
@@ -360,7 +362,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                     "hostname"
                 }
                 else {
-                    "password" | ConvertTo-SecureString -AsPlainText
+                    "password" | ConvertTo-SecureString -AsPlainText -Force
                 }
             }
         }
@@ -407,7 +409,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Write-Information -ModuleName MetasysRestClient
 
                 {
-                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText)
+                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText -Force)
                 } | Should -Throw
 
                 Should -Invoke Write-Information -ModuleName MetasysRestClient -Exactly -Times 0 -ParameterFilter {

--- a/src/MetasysRestClient/MockConsole.ps1
+++ b/src/MetasysRestClient/MockConsole.ps1
@@ -6,7 +6,7 @@ class MockConsole {
 
     static [String] $DefaultMetasysHost = "testhost"
     static [String] $DefaultUserName = "testuser"
-    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText)
+    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText -Force)
     static [string] $DefaultPath = "/objects"
 
     [Hashtable]$Inputs = @{ }
@@ -18,7 +18,7 @@ class MockConsole {
         $this.Inputs[[MockConsole]::PathPrompt] = [MockConsole]::DefaultPath
     }
 
-    MockConsole([String]$SiteHost = $DefaultSiteHost, [string]$UserName = $DefaultUserName,
+    MockConsole([String]$SiteHost = $DefaultMetasysHost, [string]$UserName = $DefaultUserName,
         [SecureString]$Password = $DefaultPassword) {
 
         $this.Inputs[[MockConsole]::MetasysHostPrompt] = $SiteHost

--- a/src/MetasysRestClient/event-parser.Tests.ps1
+++ b/src/MetasysRestClient/event-parser.Tests.ps1
@@ -1,0 +1,77 @@
+BeforeAll {
+    . ./event-parser.ps1
+}
+
+Describe "Basic event dispatching" {
+    It "parses JSON data into PSCustomObject" {
+        $parser = New-EventParser
+        $parser.Invoke('data: {"key":"value"}') | Should -BeNullOrEmpty
+        $result = $parser.Invoke("")
+        $result.Data | Should -BeOfType [PSCustomObject]
+        $result.Data.key | Should -Be "value"
+    }
+
+    It "parses event type field" {
+        $parser = New-EventParser
+        $parser.Invoke("event: myEvent") | Should -BeNullOrEmpty
+        $parser.Invoke("data: {}") | Should -BeNullOrEmpty
+        $result = $parser.Invoke("")
+        $result.EventType | Should -Be "myEvent"
+    }
+
+    It "parses event id field" {
+        $parser = New-EventParser
+        $parser.Invoke("id: abc123") | Should -BeNullOrEmpty
+        $parser.Invoke("data: {}") | Should -BeNullOrEmpty
+        $result = $parser.Invoke("")
+        $result.EventId | Should -Be "abc123"
+    }
+}
+
+Describe "Non-JSON data (regression for Fix 1)" {
+    It "does not throw and returns raw string for plain text data" {
+        $parser = New-EventParser
+        $parser.Invoke("data: hello world") | Should -BeNullOrEmpty
+        { $result = $parser.Invoke("") } | Should -Not -Throw
+        $parser2 = New-EventParser
+        $parser2.Invoke("data: hello world")
+        $result = $parser2.Invoke("")
+        $result.Data | Should -Be "hello world"
+    }
+
+    It "returns a number for numeric JSON data" {
+        $parser = New-EventParser
+        $parser.Invoke("data: 42") | Should -BeNullOrEmpty
+        $result = $parser.Invoke("")
+        $result.Data | Should -Be 42
+    }
+}
+
+Describe "id null-char check (regression for Fix 2)" {
+    It "sets EventId for a valid id value" {
+        $parser = New-EventParser
+        $parser.Invoke("id: valid-id") | Should -BeNullOrEmpty
+        $parser.Invoke("data: {}") | Should -BeNullOrEmpty
+        $result = $parser.Invoke("")
+        $result.EventId | Should -Be "valid-id"
+    }
+
+    It "does not update EventId when value contains a null character" {
+        $parser = New-EventParser
+        $nullChar = [char]0
+        $parser.Invoke("id: bad$nullChar") | Should -BeNullOrEmpty
+        $parser.Invoke("data: {}") | Should -BeNullOrEmpty
+        $result = $parser.Invoke("")
+        $result.EventId | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Comments ignored" {
+    It "ignores comment lines (does not affect data)" {
+        $parser = New-EventParser
+        $parser.Invoke(": this is a comment") | Should -BeNullOrEmpty
+        $parser.Invoke("data: {}") | Should -BeNullOrEmpty
+        $result = $parser.Invoke("")
+        $result.Data | Should -BeOfType [PSCustomObject]
+    }
+}

--- a/src/MetasysRestClient/event-parser.ps1
+++ b/src/MetasysRestClient/event-parser.ps1
@@ -25,7 +25,7 @@ function New-EventParser {
             [PSCustomObject]@{
                 EventType = $script:eventType;
                 EventId   = $script:lastEventId;
-                Data      = $script:data.ToString() | ConvertFrom-Json;
+                Data      = try { $script:data.ToString() | ConvertFrom-Json } catch { $script:data.ToString() };
             }
             $script:data = ""
             $script:eventType = ""
@@ -57,7 +57,7 @@ function New-EventParser {
             }
 
             if ($FieldName -eq "id") {
-                if (!$FieldName.Contains("\0")) {
+                if (!$Value.Contains([char]0)) {
                     $script:lastEventId = $Value
                 }
             }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,10 +1,9 @@
 # This is local sanity check test script.
+# Run Connect-MetasysAccount first to establish a session before running this script.
 
 Import-Module ./src/MetasysRestClient -Force
 
-
-
-$response = Invoke-MetasysMethod /enumerations -SiteHost diana12oas -ErrorAction Stop
+$response = Invoke-MetasysMethod /enumerations -ErrorAction Stop
 
 if ($response -isnot [String]) {
     Write-Error "Expected response to be a string not $($response.GetType())"
@@ -13,7 +12,7 @@ else {
     Write-Output "Success"
 }
 
-$response = Invoke-MetasysMethod /enumerations -SiteHost diana12oas -ReturnBodyAsObject -ErrorAction Stop
+$response = Invoke-MetasysMethod /enumerations -ReturnBodyAsObject -ErrorAction Stop
 
 if ($response -isnot [PSCustomObject] -and $response -isnot [Hashtable]) {
     Write-Error "Expected response as object to be PSCustomObject or Hashtable, not $($response.GetType()))"


### PR DESCRIPTION
## Summary

Two bugs in the SSE event parser (`event-parser.ps1`):

### Unconditional `ConvertFrom-Json`
The dispatcher always called `ConvertFrom-Json` on the accumulated SSE `data` field. SSE payloads are not always JSON — they can be plain text. This caused an unhandled exception for non-JSON events.

Fixed by wrapping `ConvertFrom-Json` in `try/catch` with a raw-string fallback.

### Wrong null-char check for `id` field
Per the SSE spec, an `id` value should be ignored if the **value** contains a null character (U+0000). The code incorrectly checked `$FieldName.Contains("\\0")` (the field name) instead of the field value.

Fixed to check `$Value.Contains([char]0)`.

Addresses comments from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).