### PR TITLE
fix: validate URI segments before indexing and fix reconnect message

### DIFF
--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -158,6 +158,49 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
 
         }
 
+        Context "Non-Metasys absolute URL is passed" {
+
+            BeforeAll {
+                $env:METASYS_VERSION = "6"
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient
+                Mock Write-Error -ModuleName MetasysRestClient
+
+                Invoke-MetasysMethod "https://some-other-host.com/not/a/metasys/url"
+            }
+
+            It "Should not invoke WebRequest (URL guard skips the request)" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times 0 -Scope Context
+            }
+
+            It "Should write an error for the invalid URL" {
+                Should -Invoke Write-Error -ModuleName MetasysRestClient -Exactly -Times 1 -Scope Context
+            }
+
+            AfterAll {
+                Remove-Item Env:\METASYS_VERSION -ErrorAction SilentlyContinue
+            }
+        }
+
+        Context "Valid Metasys absolute URL is passed" {
+
+            BeforeAll {
+                $env:METASYS_VERSION = "6"
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient
+
+                Invoke-MetasysMethod "https://oas12/api/v6/objects"
+            }
+
+            It "Should invoke WebRequest for the valid Metasys URL" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times 1 -Scope Context
+            }
+
+            AfterAll {
+                Remove-Item Env:\METASYS_VERSION -ErrorAction SilentlyContinue
+            }
+        }
+
         Context "Version and SkipCertificateCheck not supplied" {
 
             It "Should use user preference for version if set" {

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -181,6 +181,10 @@ function Invoke-MetasysMethod {
 
         $uri = [Uri]::new($path, [UriKind]::RelativeOrAbsolute)
         if ($uri.IsAbsoluteUri) {
+            if ($uri.Segments.Length -lt 3 -or $uri.Segments[1] -ne 'api/' -or $uri.Segments[2] -notmatch '^v\d+/$') {
+                Write-Error "The URL '$Path' does not appear to be a valid Metasys API URL (expected https://host/api/vN/...)"
+                continue
+            }
             $versionSegment = $uri.Segments[2]
             $versionNumber = $versionSegment.SubString(1, $versionSegment.Length - 2)
             if ($Version -ne "" -and $versionNumber -ne $Version) {
@@ -209,7 +213,7 @@ function Invoke-MetasysMethod {
                     try {
                         Write-Information "Session has expired. Trying to reconnect with this command:"
                         Write-Information "Connect-MetasysAccount -SiteHost $([MetasysEnvVars]::getSiteHost()) -UserName $([MetasysEnvVars]::getUserName()) -Version $($Version) `
--                         -SkipCertificateCheck:$($SkipCertificateCheck)"
+                         -SkipCertificateCheck:$($SkipCertificateCheck)"
                         Connect-MetasysAccount -SiteHost ([MetasysEnvVars]::getSiteHost()) -UserName ([MetasysEnvVars]::getUserName()) -Version $Version `
                             -SkipCertificateCheck:$SkipCertificateCheck
                     }


### PR DESCRIPTION
## Summary

Two issues in `Invoke-MetasysMethod.psm1`:

### Unchecked URI segment index
Absolute-URL handling accessed `$uri.Segments[2]` unconditionally. If the URL doesn't have at least 3 segments, this throws a cryptic index-out-of-bounds error. Added a `Segments.Length` check with a clear, descriptive error message for non-Metasys URLs.

### Stray `-` in reconnect message
The reconnect informational message had a stray leading `-` on a continued line, making the printed command incorrect. Removed the extra dash.

Addresses comments from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).