### PR TITLE
fix: correct test and mock setup issues

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -189,7 +189,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
 
                 $script:metasysHost = "aHost"
                 $script:userName = "aUser"
-                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText
+                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText -Force
 
                 # qualify with $script to avoid unused-vars warnings from PSScriptAnalyzer
                 $script:response = Connect-MetasysAccount -MetasysHost $script:metasysHost `
@@ -246,13 +246,15 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Get-Content -ModuleName MetasysRestClient {
                     @"
                     {
-                        "hosts": {
-                            "alias": "host",
-                            "hostname": "$($script:metasysHost)",
-                            "username": "$($script:username)",
-                            "version": "$($script:version)",
-                            "skip-certificate-check": true
-                        }
+                        "hosts": [
+                            {
+                                "alias": "host",
+                                "hostname": "$($script:metasysHost)",
+                                "username": "$($script:username)",
+                                "version": "$($script:version)",
+                                "skip-certificate-check": true
+                            }
+                        ]
                     }
 "@
                 }
@@ -360,7 +362,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                     "hostname"
                 }
                 else {
-                    "password" | ConvertTo-SecureString -AsPlainText
+                    "password" | ConvertTo-SecureString -AsPlainText -Force
                 }
             }
         }
@@ -407,7 +409,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Write-Information -ModuleName MetasysRestClient
 
                 {
-                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText)
+                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText -Force)
                 } | Should -Throw
 
                 Should -Invoke Write-Information -ModuleName MetasysRestClient -Exactly -Times 0 -ParameterFilter {

--- a/src/MetasysRestClient/MockConsole.ps1
+++ b/src/MetasysRestClient/MockConsole.ps1
@@ -6,7 +6,7 @@ class MockConsole {
 
     static [String] $DefaultMetasysHost = "testhost"
     static [String] $DefaultUserName = "testuser"
-    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText)
+    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText -Force)
     static [string] $DefaultPath = "/objects"
 
     [Hashtable]$Inputs = @{ }
@@ -18,7 +18,7 @@ class MockConsole {
         $this.Inputs[[MockConsole]::PathPrompt] = [MockConsole]::DefaultPath
     }
 
-    MockConsole([String]$SiteHost = $DefaultSiteHost, [string]$UserName = $DefaultUserName,
+    MockConsole([String]$SiteHost = $DefaultMetasysHost, [string]$UserName = $DefaultUserName,
         [SecureString]$Password = $DefaultPassword) {
 
         $this.Inputs[[MockConsole]::MetasysHostPrompt] = $SiteHost

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,10 +1,9 @@
 # This is local sanity check test script.
+# Run Connect-MetasysAccount first to establish a session before running this script.
 
 Import-Module ./src/MetasysRestClient -Force
 
-
-
-$response = Invoke-MetasysMethod /enumerations -SiteHost diana12oas -ErrorAction Stop
+$response = Invoke-MetasysMethod /enumerations -ErrorAction Stop
 
 if ($response -isnot [String]) {
     Write-Error "Expected response to be a string not $($response.GetType())"
@@ -13,7 +12,7 @@ else {
     Write-Output "Success"
 }
 
-$response = Invoke-MetasysMethod /enumerations -SiteHost diana12oas -ReturnBodyAsObject -ErrorAction Stop
+$response = Invoke-MetasysMethod /enumerations -ReturnBodyAsObject -ErrorAction Stop
 
 if ($response -isnot [PSCustomObject] -and $response -isnot [Hashtable]) {
     Write-Error "Expected response as object to be PSCustomObject or Hashtable, not $($response.GetType()))"


### PR DESCRIPTION
## Summary

Three test/mock correctness issues that cause test failures or incorrect test behavior:

### Mock hosts config wrong type

`Connect-MetasysAccount.Tests.ps1`: mock config JSON had `hosts` as an object; `Read-ConfigFile` expects an array and calls `.Where()`. Fixed mock to use an array.

### Wrong property name in MockConsole

`MockConsole.ps1`: referenced `$DefaultSiteHost` but the class defines `DefaultMetasysHost`, so the default was always `$null`. Fixed property name.

### Non-existent `-SiteHost` parameter

`test/test.ps1`: called `Invoke-MetasysMethod -SiteHost ...` but that parameter doesn't exist. Removed it and added comment to run `Connect-MetasysAccount` first.

Addresses comments from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).