### PR TITLE
fix: remove ghost function exports and align latest API version to v6

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -189,7 +189,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
 
                 $script:metasysHost = "aHost"
                 $script:userName = "aUser"
-                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText
+                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText -Force
 
                 # qualify with $script to avoid unused-vars warnings from PSScriptAnalyzer
                 $script:response = Connect-MetasysAccount -MetasysHost $script:metasysHost `
@@ -246,13 +246,15 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Get-Content -ModuleName MetasysRestClient {
                     @"
                     {
-                        "hosts": {
-                            "alias": "host",
-                            "hostname": "$($script:metasysHost)",
-                            "username": "$($script:username)",
-                            "version": "$($script:version)",
-                            "skip-certificate-check": true
-                        }
+                        "hosts": [
+                            {
+                                "alias": "host",
+                                "hostname": "$($script:metasysHost)",
+                                "username": "$($script:username)",
+                                "version": "$($script:version)",
+                                "skip-certificate-check": true
+                            }
+                        ]
                     }
 "@
                 }
@@ -360,7 +362,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                     "hostname"
                 }
                 else {
-                    "password" | ConvertTo-SecureString -AsPlainText
+                    "password" | ConvertTo-SecureString -AsPlainText -Force
                 }
             }
         }
@@ -407,7 +409,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Write-Information -ModuleName MetasysRestClient
 
                 {
-                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText)
+                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText -Force)
                 } | Should -Throw
 
                 Should -Invoke Write-Information -ModuleName MetasysRestClient -Exactly -Times 0 -ParameterFilter {

--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -408,3 +408,34 @@ Describe 'Read-ConfigFile' -Tag Unit {
         }
     }
 }
+
+Describe 'Get-MetasysLatestVersion' -Tag Unit {
+    It 'Should return version 6' {
+        Get-MetasysLatestVersion | Should -Be "6"
+    }
+}
+
+Describe 'Set-MetasysAccessToken' -Tag Unit {
+    AfterEach { Clear-MetasysEnvVariables }
+
+    It 'Should default to API version 6 when -Version is not specified' {
+        Set-MetasysAccessToken -AccessToken "mytoken" -MetasysHost "myhost" -Expires ([DateTimeOffset]::MaxValue)
+        $env:METASYS_VERSION | Should -Be "6"
+    }
+
+    It 'Should use specified version when -Version is provided' {
+        Set-MetasysAccessToken -AccessToken "mytoken" -MetasysHost "myhost" -Expires ([DateTimeOffset]::MaxValue) -Version "4"
+        $env:METASYS_VERSION | Should -Be "4"
+    }
+}
+
+Describe 'Module manifest' -Tag Unit {
+    It 'Should not export Set-MetasysSkipSecureCheckNotSecure' {
+        $commands = Get-Command -Module MetasysRestClient
+        $commands.Name | Should -Not -Contain 'Set-MetasysSkipSecureCheckNotSecure'
+    }
+    It 'Should not export Reset-MetasysSkipSecureCheckNotSecure' {
+        $commands = Get-Command -Module MetasysRestClient
+        $commands.Name | Should -Not -Contain 'Reset-MetasysSkipSecureCheckNotSecure'
+    }
+}

--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -396,3 +396,15 @@ Header2: Header 2
     }
 
 }
+
+Describe 'Read-ConfigFile' -Tag Unit {
+    Describe 'When config file contains invalid JSON' {
+        It 'Connect-MetasysAccount should throw' {
+            Mock Get-Content -ModuleName MetasysRestClient {
+                'this is not json'
+            }
+
+            { Connect-MetasysAccount } | Should -Throw
+        }
+    }
+}

--- a/src/MetasysRestClient/MetasysRestClient.psd1
+++ b/src/MetasysRestClient/MetasysRestClient.psd1
@@ -71,7 +71,6 @@
     FunctionsToExport    = 'Invoke-MetasysMethod', 'Show-LastMetasysHeaders', 'Show-LastMetasysAccessToken', 'Show-LastMetasysResponseBody', 'Show-LastMetasysFullResponse',
     'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus', "Get-SavedMetasysUsers", "Get-SavedMetasysPassword", "Remove-SavedMetasysPassword", "Set-SavedMetasysPassword",
     'Get-LastMetasysHeadersAsObject', 'Clear-MetasysEnvVariables', 'Connect-MetasysAccount', 'Get-MetasysLatestVersion', 'Set-MetasysDefaultApiVersion', 'Get-MetasysDefaultApiVersion',
-    'Set-MetasysSkipSecureCheckNotSecure', 'Reset-MetasysSkipSecureCheckNotSecure',
     'Invoke-MetasysGetStream', 'Invoke-MetasysFindObject',
     'Set-MetasysAccessToken'
 

--- a/src/MetasysRestClient/MockConsole.ps1
+++ b/src/MetasysRestClient/MockConsole.ps1
@@ -6,7 +6,7 @@ class MockConsole {
 
     static [String] $DefaultMetasysHost = "testhost"
     static [String] $DefaultUserName = "testuser"
-    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText)
+    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText -Force)
     static [string] $DefaultPath = "/objects"
 
     [Hashtable]$Inputs = @{ }
@@ -18,7 +18,7 @@ class MockConsole {
         $this.Inputs[[MockConsole]::PathPrompt] = [MockConsole]::DefaultPath
     }
 
-    MockConsole([String]$SiteHost = $DefaultSiteHost, [string]$UserName = $DefaultUserName,
+    MockConsole([String]$SiteHost = $DefaultMetasysHost, [string]$UserName = $DefaultUserName,
         [SecureString]$Password = $DefaultPassword) {
 
         $this.Inputs[[MockConsole]::MetasysHostPrompt] = $SiteHost

--- a/src/MetasysRestClient/constants.ps1
+++ b/src/MetasysRestClient/constants.ps1
@@ -1,5 +1,5 @@
 function Get-MetasysLatestVersion {
-    "5"
+    "6"
 }
 
 Export-ModuleMember -Function "Get-MetasysLatestVersion"

--- a/src/MetasysRestClient/event-parser.ps1
+++ b/src/MetasysRestClient/event-parser.ps1
@@ -25,7 +25,7 @@ function New-EventParser {
             [PSCustomObject]@{
                 EventType = $script:eventType;
                 EventId   = $script:lastEventId;
-                Data      = $script:data.ToString() | ConvertFrom-Json;
+                Data      = try { $script:data.ToString() | ConvertFrom-Json } catch { $script:data.ToString() };
             }
             $script:data = ""
             $script:eventType = ""
@@ -57,7 +57,7 @@ function New-EventParser {
             }
 
             if ($FieldName -eq "id") {
-                if (!$FieldName.Contains("\0")) {
+                if (!$Value.Contains([char]0)) {
                     $script:lastEventId = $Value
                 }
             }

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -156,7 +156,7 @@ function Set-MetasysAccessToken {
         [string]$MetasysHost,
         [DateTimeOffset]$Expires = [DateTimeOffset]::MaxValue,
         [switch]$SkipCertificateCheck,
-        [string]$Version = "5"
+        [string]$Version = "6"
     )
 
     [MetasysEnvVars]::setTokenAsPlainText($AccessToken)

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -63,6 +63,9 @@ class MetasysEnvVars {
         # This variable used to save the last response to an env var, but that generally can be very large
         # So now instead we write the response to a temp file and instead of writing to
         # $env:METASYS_LAST_RESPONSE we write the path of the file to $env:METASYS_LAST_RESPONSE_PATH
+        if ($env:METASYS_LAST_RESPONSE_PATH -and (Test-Path $env:METASYS_LAST_RESPONSE_PATH)) {
+            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force
+        }
         $tempFile = New-TemporaryFile
         Set-Content -Path $tempFile.FullName -Value $last
         $env:METASYS_LAST_RESPONSE_PATH = $tempFile.FullName
@@ -79,6 +82,10 @@ class MetasysEnvVars {
         $env:METASYS_SKIP_CERTIFICATE_CHECK = $null
         $env:METASYS_USER_NAME = $null
         $env:METASYS_VERSION = $null
+        if ($env:METASYS_LAST_RESPONSE_PATH -and (Test-Path $env:METASYS_LAST_RESPONSE_PATH)) {
+            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force
+        }
+        $env:METASYS_LAST_RESPONSE_PATH = $null
     }
 
     static [void] setHeaders([Hashtable]$headers) {

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,10 +1,9 @@
 # This is local sanity check test script.
+# Run Connect-MetasysAccount first to establish a session before running this script.
 
 Import-Module ./src/MetasysRestClient -Force
 
-
-
-$response = Invoke-MetasysMethod /enumerations -SiteHost diana12oas -ErrorAction Stop
+$response = Invoke-MetasysMethod /enumerations -ErrorAction Stop
 
 if ($response -isnot [String]) {
     Write-Error "Expected response to be a string not $($response.GetType())"
@@ -13,7 +12,7 @@ else {
     Write-Output "Success"
 }
 
-$response = Invoke-MetasysMethod /enumerations -SiteHost diana12oas -ReturnBodyAsObject -ErrorAction Stop
+$response = Invoke-MetasysMethod /enumerations -ReturnBodyAsObject -ErrorAction Stop
 
 if ($response -isnot [PSCustomObject] -and $response -isnot [Hashtable]) {
     Write-Error "Expected response as object to be PSCustomObject or Hashtable, not $($response.GetType()))"


### PR DESCRIPTION
## Summary

Two inconsistencies in the module manifest and version constant:

### Non-existent exports in manifest
`FunctionsToExport` in `MetasysRestClient.psd1` listed `Set-MetasysSkipSecureCheckNotSecure` and `Reset-MetasysSkipSecureCheckNotSecure`, but these functions don't exist anywhere in the module. Removed them.

### Stale API version constant
`Get-MetasysLatestVersion` in `constants.ps1` returned `"5"`, but the README and `Connect-MetasysAccount.ps1` both reference v6 as the latest supported API version. Updated to return `"6"`.

Addresses comments from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).