### PR TITLE
fix: add -Force to ConvertTo-SecureString -AsPlainText for PS7+ compatibility

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -189,7 +189,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
 
                 $script:metasysHost = "aHost"
                 $script:userName = "aUser"
-                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText
+                $script:securePassword = "aPassword" | ConvertTo-SecureString -AsPlainText -Force
 
                 # qualify with $script to avoid unused-vars warnings from PSScriptAnalyzer
                 $script:response = Connect-MetasysAccount -MetasysHost $script:metasysHost `
@@ -360,7 +360,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                     "hostname"
                 }
                 else {
-                    "password" | ConvertTo-SecureString -AsPlainText
+                    "password" | ConvertTo-SecureString -AsPlainText -Force
                 }
             }
         }
@@ -407,7 +407,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Write-Information -ModuleName MetasysRestClient
 
                 {
-                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText)
+                    Connect-MetasysAccount -h oas -u user -p (password | ConvertTo-SecureString -AsPlainText -Force)
                 } | Should -Throw
 
                 Should -Invoke Write-Information -ModuleName MetasysRestClient -Exactly -Times 0 -ParameterFilter {

--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -104,7 +104,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
     Describe "When Token Stored in Env Vars and Token is not expired, and SiteHost stored in env vars" {
         BeforeAll {
             Clear-MetasysEnvVariables
-            $env:METASYS_ACCESS_TOKEN = (ConvertTo-SecureString -AsPlainText "This is the token") | ConvertFrom-SecureString
+            $env:METASYS_ACCESS_TOKEN = (ConvertTo-SecureString -AsPlainText -Force "This is the token") | ConvertFrom-SecureString
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
             $env:METASYS_HOST = "oas12"
         }
@@ -192,7 +192,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
         BeforeAll {
             Clear-MetasysEnvVariables
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow - [TimeSpan]::FromMinutes(5)).ToString("o")
-            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
             $env:METASYS_VERSION = $LatestVersion
             $env:METASYS_HOST = "oas12"
             $env:METASYS_USER_NAME = "api"
@@ -205,7 +205,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
                 Mock Invoke-WebRequest -ModuleName MetasysRestClient
                 Mock Connect-MetasysAccount -ModuleName MetasysRestClient
                 Mock Get-SavedMetasysPassword -ModuleName MetasysRestClient {
-                    ConvertTo-SecureString -String "ThePassword" -AsPlainText
+                    ConvertTo-SecureString -String "ThePassword" -AsPlainText -Force
                 }
 
                 Invoke-MetasysMethod /objects
@@ -263,7 +263,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             BeforeAll {
                 Clear-MetasysEnvVariables
                 $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow - [TimeSpan]::FromMinutes(5)).ToString("o")
-                $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+                $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
                 $env:METASYS_VERSION = $LatestVersion
             }
 
@@ -296,7 +296,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             BeforeAll {
                 Clear-MetasysEnvVariables
                 $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(2)).ToString("o")
-                $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+                $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
                 $env:METASYS_VERSION = $LatestVersion
                 $env:METASYS_HOST = "oas12"
             }
@@ -319,7 +319,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
         BeforeAll {
             Clear-MetasysEnvVariables
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
-            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
             $env:METASYS_VERSION = $LatestVersion
             $env:METASYS_HOST = "oas12"
         }
@@ -359,7 +359,7 @@ Header2: Header 2
         BeforeAll {
             Clear-MetasysEnvVariables
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
-            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
             $env:METASYS_VERSION = $LatestVersion
             $env:METASYS_HOST = "oas12"
         }

--- a/src/MetasysRestClient/MockConsole.ps1
+++ b/src/MetasysRestClient/MockConsole.ps1
@@ -6,7 +6,7 @@ class MockConsole {
 
     static [String] $DefaultMetasysHost = "testhost"
     static [String] $DefaultUserName = "testuser"
-    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText)
+    static [SecureString] $DefaultPassword = (ConvertTo-SecureString "testpassword" -AsPlainText -Force)
     static [string] $DefaultPath = "/objects"
 
     [Hashtable]$Inputs = @{ }

--- a/src/MetasysRestClient/PasswordManagement.Tests.ps1
+++ b/src/MetasysRestClient/PasswordManagement.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Password Management When No Vaults Registered" {
                 Mock Get-SecretVault -ModuleName MetasysRestClient
             }
             Mock Write-Information -ModuleName MetasysRestClient
-            $result = Set-SavedMetasysPassword -SiteHost anything -UserName anything -Password (ConvertTo-SecureString anything -AsPlainText)
+            $result = Set-SavedMetasysPassword -SiteHost anything -UserName anything -Password (ConvertTo-SecureString anything -AsPlainText -Force)
             if (!$result) {
                 $returnedNothing = $true
             }
@@ -153,7 +153,7 @@ Describe "Password Management When Vault Registered but the module for that vaul
                 Mock Get-SecretVault -ModuleName MetasysRestClient
             }
             Mock Write-Information -ModuleName MetasysRestClient
-            $result = Set-SavedMetasysPassword -SiteHost anything -UserName anything -Password (ConvertTo-SecureString anything -AsPlainText)
+            $result = Set-SavedMetasysPassword -SiteHost anything -UserName anything -Password (ConvertTo-SecureString anything -AsPlainText -Force)
             if (!$result) {
                 $returnedNothing = $true
             }
@@ -247,7 +247,7 @@ Describe "Password Management When a Single Vault is registered" {
                 Mock Get-SecretVault -ModuleName MetasysRestClient
             }
             Mock Write-Information -ModuleName MetasysRestClient
-            $result = Set-SavedMetasysPassword -SiteHost anything -UserName anything -Password (ConvertTo-SecureString anything -AsPlainText)
+            $result = Set-SavedMetasysPassword -SiteHost anything -UserName anything -Password (ConvertTo-SecureString anything -AsPlainText -Force)
             if (!$result) {
                 $returnedNothing = $true
             }

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -49,7 +49,7 @@ class MetasysEnvVars {
     }
 
     static [void] setTokenAsPlainText([String]$token) {
-        [MetasysEnvVars]::setToken(($token | ConvertTo-SecureString -AsPlainText))
+        [MetasysEnvVars]::setToken(($token | ConvertTo-SecureString -AsPlainText -Force))
     }
 
     static [string] getLast() {


### PR DESCRIPTION
## Summary

In PowerShell 7+, `ConvertTo-SecureString -AsPlainText` requires `-Force` or it throws. This was missing in 5 locations, breaking all CI runs on modern PowerShell.

## Changes
- `metasys-env-vars.ps1`: `setTokenAsPlainText` method
- `Connect-MetasysAccount.Tests.ps1`: test SecureString creation
- `PasswordManagement.Tests.ps1`: test SecureString creation
- `MockConsole.ps1`: `$DefaultPassword` default value
- `Invoke-MetasysMethod.Tests.ps1`: test env var setup

Addresses comments from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).