### PR TITLE
fix: clean up previous temp file in setLast and clear()

### DIFF
--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -355,6 +355,70 @@ Header2: Header 2
     }
 
 
+    Describe 'Temp file cleanup (regression tests for temp file leak)' {
+
+        Describe 'setLast called twice should clean up first temp file' {
+            BeforeAll {
+                Clear-MetasysEnvVariables
+                $env:METASYS_ACCESS_TOKEN = (ConvertTo-SecureString -AsPlainText "This is the token") | ConvertFrom-SecureString
+                $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
+                $env:METASYS_HOST = "oas12"
+                $env:METASYS_VERSION = $LatestVersion
+            }
+
+            It 'first temp file should be deleted after second call to Invoke-MetasysMethod' {
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    @{
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                        Content           = [System.Text.Encoding]::UTF8.GetBytes('"response1"')
+                    }
+                }
+                Invoke-MetasysMethod /objects | Out-Null
+                $firstPath = $env:METASYS_LAST_RESPONSE_PATH
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    @{
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                        Content           = [System.Text.Encoding]::UTF8.GetBytes('"response2"')
+                    }
+                }
+                Invoke-MetasysMethod /objects | Out-Null
+
+                $firstPath | Should -Not -Exist
+                $env:METASYS_LAST_RESPONSE_PATH | Should -Not -BeNullOrEmpty
+                $env:METASYS_LAST_RESPONSE_PATH | Should -Exist
+            }
+
+            AfterAll {
+                Clear-MetasysEnvVariables
+            }
+        }
+
+        Describe 'Clear-MetasysEnvVariables removes the temp file' {
+            It 'should delete the temp file and null out METASYS_LAST_RESPONSE_PATH' {
+                $tempFile = [System.IO.Path]::GetTempFileName()
+                $env:METASYS_LAST_RESPONSE_PATH = $tempFile
+
+                Clear-MetasysEnvVariables | Out-Null
+
+                $tempFile | Should -Not -Exist
+                $env:METASYS_LAST_RESPONSE_PATH | Should -BeNullOrEmpty
+            }
+        }
+
+        Describe 'Clear-MetasysEnvVariables is safe when no temp file exists' {
+            It 'should not throw when METASYS_LAST_RESPONSE_PATH is null' {
+                $env:METASYS_LAST_RESPONSE_PATH = $null
+
+                { Clear-MetasysEnvVariables } | Should -Not -Throw
+            }
+        }
+    }
+
     Describe 'When -IncludeResponseHeaders with response error' {
         BeforeAll {
             Clear-MetasysEnvVariables

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -64,7 +64,7 @@ class MetasysEnvVars {
         # So now instead we write the response to a temp file and instead of writing to
         # $env:METASYS_LAST_RESPONSE we write the path of the file to $env:METASYS_LAST_RESPONSE_PATH
         if ($env:METASYS_LAST_RESPONSE_PATH -and (Test-Path $env:METASYS_LAST_RESPONSE_PATH)) {
-            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force
+            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force -ErrorAction SilentlyContinue
         }
         $tempFile = New-TemporaryFile
         Set-Content -Path $tempFile.FullName -Value $last
@@ -83,7 +83,7 @@ class MetasysEnvVars {
         $env:METASYS_USER_NAME = $null
         $env:METASYS_VERSION = $null
         if ($env:METASYS_LAST_RESPONSE_PATH -and (Test-Path $env:METASYS_LAST_RESPONSE_PATH)) {
-            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force
+            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force -ErrorAction SilentlyContinue
         }
         $env:METASYS_LAST_RESPONSE_PATH = $null
     }

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -63,6 +63,9 @@ class MetasysEnvVars {
         # This variable used to save the last response to an env var, but that generally can be very large
         # So now instead we write the response to a temp file and instead of writing to
         # $env:METASYS_LAST_RESPONSE we write the path of the file to $env:METASYS_LAST_RESPONSE_PATH
+        if ($env:METASYS_LAST_RESPONSE_PATH -and (Test-Path $env:METASYS_LAST_RESPONSE_PATH)) {
+            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force
+        }
         $tempFile = New-TemporaryFile
         Set-Content -Path $tempFile.FullName -Value $last
         $env:METASYS_LAST_RESPONSE_PATH = $tempFile.FullName
@@ -79,6 +82,10 @@ class MetasysEnvVars {
         $env:METASYS_SKIP_CERTIFICATE_CHECK = $null
         $env:METASYS_USER_NAME = $null
         $env:METASYS_VERSION = $null
+        if ($env:METASYS_LAST_RESPONSE_PATH -and (Test-Path $env:METASYS_LAST_RESPONSE_PATH)) {
+            Remove-Item -Path $env:METASYS_LAST_RESPONSE_PATH -Force
+        }
+        $env:METASYS_LAST_RESPONSE_PATH = $null
     }
 
     static [void] setHeaders([Hashtable]$headers) {


### PR DESCRIPTION
## Summary

Each call to `setLast` created a new temp file but never removed the previous one, leaking temp files indefinitely. `clear()` also left the temp file on disk and left `METASYS_LAST_RESPONSE_PATH` set.

## Changes (`metasys-env-vars.ps1`)
- `setLast`: delete previous temp file (if any) before creating a new one
- `clear()`: remove the temp file pointed to by `METASYS_LAST_RESPONSE_PATH` and unset the env var

Addresses comment from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).