### PR TITLE
fix: correct documentation typos and inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ When the JSON string is relatively short like in this example you can just type
 it all on one line:
 
 ```powershell
-Invoke-MetasysMethod -Method Patch /objects/$Id  -Body "{ 'item': { 'description': 'Zone 3 Temperature Set Point' } }"
+Invoke-MetasysMethod -Method Patch /objects/$Id  -Body '{ "item": { "description": "Zone 3 Temperature Set Point" } }'
 ```
 
 We'll read it back to ensure it changed:
@@ -1610,8 +1610,8 @@ PS > cd src/MetasysRestClient
 PS > Invoke-Pester
 ```
 
-Or simply use the script `runtests.ps1` in the root
+Or simply use the script `run-tests.ps1` in the root
 
 ```powershell
-PS > ./runtests.ps1
+PS > ./run-tests.ps1
 ```

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -58,7 +58,7 @@ PS > $descriptionUpdate = @"
 >>   }
 >> }
 >> "@
-PS > Invoke-MetsysMethod /objects/$Id -Method Patch -Body $descriptionUpdate
+PS > Invoke-MetasysMethod /objects/$Id -Method Patch -Body $descriptionUpdate
 ```
 
 ### Using a Hashtable
@@ -117,7 +117,7 @@ PS > Write-Output $updateJSON
     }
   }
 }
-PS > imm /objects/$Id -Method Path -Body $updateJSON
+PS > imm /objects/$Id -Method Patch -Body $updateJSON
 ```
 
 ### Using the Contents of File

--- a/src/MetasysRestClient/Read-ConfigFile.ps1
+++ b/src/MetasysRestClient/Read-ConfigFile.ps1
@@ -20,14 +20,14 @@ function Read-ConfigFile {
         if ($configs) {
             $hosts = $configs.hosts
             if ($hosts) {
-                # Return the last match option
+                # Return the first match
                 $hostEntry = $hosts.Where{ $_.alias -eq $Alias} | Select-Object -First 1
                 if ($hostEntry.psobject.properties['hostname']) {
                     $hostEntry
                 }
             }
         } else {
-            $path = $HOME + "/.metasysapirc"
+            $path = $HOME + "/.metasysrestclient"
             Write-Error "Cannot parse '$path' file. Expected valid JSON."
             Exit
         }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -16,7 +16,7 @@ else {
 $response = Invoke-MetasysMethod /enumerations -SiteHost diana12oas -ReturnBodyAsObject -ErrorAction Stop
 
 if ($response -isnot [PSCustomObject] -and $response -isnot [Hashtable]) {
-    Write-Error "Expected response as object to be PSCustomObject or Hashtable, not $($response.GetType()))"
+    Write-Error "Expected response as object to be PSCustomObject or Hashtable, not $($response.GetType())"
 }
 else {
     Write-Output "Success"


### PR DESCRIPTION
## Summary

Seven documentation fixes across tips, README, test script, and source comments:

1. `docs/tips.md`: `Invoke-MetsysMethod` → `Invoke-MetasysMethod` (typo)
2. `docs/tips.md`: `-Method Path` → `-Method Patch` (wrong HTTP verb)
3. `README.md`: PATCH example body used invalid single-quoted JSON; fixed to use double quotes
4. `README.md`: wrong test script reference `runtests.ps1` → `run-tests.ps1`
5. `test/test.ps1`: extra closing `)` in error message string
6. `Read-ConfigFile.ps1`: wrong config file path in error message (`~/.metasysapirc` → `~/.metasysrestclient`) (if not already fixed)
7. `Read-ConfigFile.ps1`: comment said "last match" but `Select-Object -First 1` returns the first match

Addresses comments from [mirror PR #2](https://github.com/jci-internal-dev/cp-metasys-powershell-restclient/pull/2).