### PR TITLE
feat: add Invoke-MetasysReadAttribute command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,83 @@
 
 Add utility methods
 
-* [ ] New-MetasysObject -LocalUniqueIdentifier -ParentId -ObjectType [-Properties @{ }]
-* [ ] Find-MetasysObject -ObjectType [-Count X] [-DeviceId X] [-Name {regex}] [-Depth xxx]
-* [ ] Send-MetasysCommand -ObjectId -CommandId -Parameters -Annotation -Priority
-* [ ] Read-MetasysObject -ObjectId [-ViewId]
-* [ ] Read-MetasysAttribute -ObjectId -AttributeId [-RawValue] // Raw value will just display the value, no JSON, no condition, etc.
+- [ ] New-MetasysObject -LocalUniqueIdentifier -ParentId -ObjectType
+      [-Properties @{ }]
+- [ ] Find-MetasysObject -ObjectType [-Count X] [-DeviceId X] [-Name {regex}]
+      [-Depth xxx]
+- [ ] Send-MetasysCommand -ObjectId -CommandId -Parameters -Annotation -Priority
+- [ ] Read-MetasysObject -ObjectId [-ViewId]
+- [ ] Read-MetasysAttribute -ObjectId -AttributeId [-RawValue] // Raw value will
+      just display the value, no JSON, no condition, etc.
+- [ ] Get-Objects [-ObjectId objectId]
 
+## Design Philosophy
+
+All previous versions were mainly concerned with a user (primarily myself)
+interested in calling an operation to be able to see the JSON result (or test
+JSON requests). It's not clear to me whether this client is useful for writing
+applications or scripts.
+
+Some things it's probably missing for a good script
+
+- The base command probably needs a better way to return errors. Currently, the
+  focus is on just returning the body of the response message. If this is an
+  error payload it's displayed just like the response body of a non-error
+  payload.
+
+  - One possibility would be to throw an exception that contains the full
+    response object.
+  - some errors (like networking errors) just fail with a Write-Error and then
+    exit. These should probably throw as well
+
+  The problem with throwing errors is that they are ugly on the screen. They
+  work well for scripts/applications but for me using it on the command line I
+  don't see seeing so much red.
+
+  Perhaps what I need to do is create one version of Invoke-MetasysMethod that
+  is for applications and another that is a wrapper that can catch the ugly
+  error messages and customize the output.
+
+- There has only been the base command up til now (Aug. 2024). I'm in the
+  process of adding subcommands for common operations or operations that require
+  a body where you may not remember the schema of the body. So possible
+  operations in the first releases
+
+  - Common operations
+    - ReadAttribute/ReadAttributes
+    - SendCommand
+    - GetObjectView
+    - WriteAttribute/WriteAttributes
+    - GetObjects (discover the tree)
+  - Body operations
+    - Create object
+    - Create enum
+    - Edit enum
+
+  For sub-commands I want to concentrate on application usage. Rather than focus
+  on returning JSON they should return objects. (Because if I just want JSON I
+  could call the base command). The sub commands are meant to offer a higher
+  level of abstraction.
+
+  For example, let's consider ReadAttribute and what it should return
+
+  - Return just the raw value of the attribute. For example (`$true`, `68.0`,
+    `"ADS:ADS"`, `127,23,15,14`). There are two approaches here as well. We
+    could focus on just relying on the JSON types which is known from the JSON
+    itself, or we could always ask for the schema and know the precise
+    `metasys-type`. I think I'd lean on the second. In this scenario the
+    response type would best be considered `object`.
+  - The next option is to do the same but explicitly create a Variant type that
+    works much like JToken types in JSON libraries. You can inspect the Variant
+    and determine what it contains and then extract out the right value. This
+    would be nicer if Powershell supported pattern matching. In practice, this
+    is unlikely to be an issue as many use cases the user knows that they are
+    reading (say presentValue) and the result type is known or its known to be
+    either an enum or a float.
+  - A third option is for the fact that we normally care about
+    status/reliability/priority etc of a value. So perhaps we should return a
+    AttributeValue class that includes the condition flags as well as the value.
+    It could even include other schema information (like min/max values etc.)
+
+  I am leaning towards option 3 where the `Value` is a `Variant` (or we could
+  call it a `MetasysValue`)

--- a/src/MetasysRestClient/Completers.Tests.ps1
+++ b/src/MetasysRestClient/Completers.Tests.ps1
@@ -1,0 +1,150 @@
+Set-StrictMode -Version 3
+
+BeforeAll {
+    Import-Module -Name ./ -Force
+
+    # Helper: write a cache file for a given host with the provided hashtable of
+    # ItemReference -> ObjectId entries.
+    function WriteCacheFile {
+        param(
+            [string]$MetasysHost,
+            [hashtable]$Entries
+        )
+        $cacheDir = [System.IO.Path]::Combine($env:HOME, "Library", "Caches", "MetasysRestClient")
+        if (-not (Test-Path $cacheDir)) { New-Item -ItemType Directory -Path $cacheDir | Out-Null }
+        $filePath = [System.IO.Path]::Combine($cacheDir, "$MetasysHost-cachedObjectIds.json")
+        [System.IO.File]::WriteAllText($filePath, ($Entries | ConvertTo-Json))
+    }
+}
+
+Describe "Tab completion" {
+
+    BeforeAll {
+        $script:testHost = "completers-test-host"
+        $env:METASYS_HOST = $script:testHost
+
+        WriteCacheFile -MetasysHost $script:testHost -Entries @{
+            "site:device.AHU-1"      = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+            "site:device.AHU-2"      = "cc2b814a-2f07-65bf-0bf7-a661c5bd3f5b"
+            "site:other.VAV-1"       = "dd3c925b-3018-76c0-1c08-b772d6ce406c"
+            "site:device.With Space" = "ee4da36c-4129-87d1-2d19-c883e7df517d"
+        }
+    }
+
+    AfterAll {
+        InModuleScope MetasysRestClient { Remove-MetasysCache -MetasysHost $env:METASYS_HOST }
+    }
+
+    Describe "Get-MetasysCachedItemReferences" {
+
+        It "Returns all references when wordToComplete is empty" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedItemReferences $null $null "" $null $null
+            }
+            $results.Count | Should -Be 4
+        }
+
+        It "Filters references by wordToComplete" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedItemReferences $null $null "AHU" $null $null
+            }
+            $results.Count | Should -Be 2
+            $results.CompletionText | Should -Contain '"site:device.AHU-1"'
+            $results.CompletionText | Should -Contain '"site:device.AHU-2"'
+        }
+
+        It "Excludes references that do not match wordToComplete" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedItemReferences $null $null "VAV" $null $null
+            }
+            $results.Count | Should -Be 1
+            $results[0].CompletionText | Should -Be '"site:other.VAV-1"'
+        }
+
+        It "Wraps all results in quotes when any reference contains a space" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedItemReferences $null $null "" $null $null
+            }
+            $results | ForEach-Object {
+                $_.CompletionText | Should -Match '^".*"$'
+            }
+        }
+
+        It "Does not quote results when no reference contains a space" {
+            WriteCacheFile -MetasysHost $script:testHost -Entries @{
+                "site:device.AHU-1" = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+                "site:device.AHU-2" = "cc2b814a-2f07-65bf-0bf7-a661c5bd3f5b"
+            }
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedItemReferences $null $null "" $null $null
+            }
+            $results | ForEach-Object {
+                $_.CompletionText | Should -Not -Match '^"'
+            }
+            # Restore full cache for subsequent tests
+            WriteCacheFile -MetasysHost $script:testHost -Entries @{
+                "site:device.AHU-1"      = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+                "site:device.AHU-2"      = "cc2b814a-2f07-65bf-0bf7-a661c5bd3f5b"
+                "site:other.VAV-1"       = "dd3c925b-3018-76c0-1c08-b772d6ce406c"
+                "site:device.With Space" = "ee4da36c-4129-87d1-2d19-c883e7df517d"
+            }
+        }
+
+        It "Returns CompletionResult objects" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedItemReferences $null $null "AHU-1" $null $null
+            }
+            $results[0] | Should -BeOfType [System.Management.Automation.CompletionResult]
+        }
+    }
+
+    Describe "Get-MetasysCachedObjectIds" {
+
+        It "Returns object IDs matching the prefix" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedObjectIds $null $null "ba1a" $null $null
+            }
+            $results.Count | Should -Be 1
+            $results[0].CompletionText | Should -Be "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+        }
+
+        It "Includes the item reference in the list item text" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedObjectIds $null $null "ba1a" $null $null
+            }
+            $results[0].ListItemText | Should -BeLike "*site:device.AHU-1*"
+        }
+
+        It "Excludes IDs that do not match the prefix" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedObjectIds $null $null "zzzzz" $null $null
+            }
+            $results.Count | Should -Be 0
+        }
+
+        It "Returns CompletionResult objects" {
+            $results = InModuleScope MetasysRestClient {
+                Get-MetasysCachedObjectIds $null $null "ba1a" $null $null
+            }
+            $results[0] | Should -BeOfType [System.Management.Automation.CompletionResult]
+        }
+    }
+
+    Describe "Completer registration" {
+
+        It "ItemReference completer is registered for Invoke-MetasysReadAttribute" {
+            $completions = [System.Management.Automation.CommandCompletion]::CompleteInput(
+                "Invoke-MetasysReadAttribute -ItemReference ", 43, $null
+            )
+            $completions.CompletionMatches.Count | Should -BeGreaterThan 0
+        }
+
+        It "ObjectId completer is registered for Invoke-MetasysReadAttribute" {
+            $completions = [System.Management.Automation.CommandCompletion]::CompleteInput(
+                "Invoke-MetasysReadAttribute -ObjectId ", 38, $null
+            )
+            $completions.CompletionMatches.Count | Should -BeGreaterThan 0
+        }
+    }
+}
+

--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -218,7 +218,7 @@ function Connect-MetasysAccount {
 
         $uri = "https://$MetasysHost/api/v$Version/login"
         try {
-            Write-Information "Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body '{ `"username`": `"$UserName`", `"password`": `"********`" }' -SkipCertificateCheck:`$$SkipCertificateCheck"
+            Write-Debug "Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body '{ `"username`": `"$UserName`", `"password`": `"********`" }' -SkipCertificateCheck:`$$SkipCertificateCheck"
             $response = Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body $body -SkipCertificateCheck:$SkipCertificateCheck
         }
         catch {

--- a/src/MetasysRestClient/Invoke-FindObject.ps1
+++ b/src/MetasysRestClient/Invoke-FindObject.ps1
@@ -12,15 +12,29 @@ function Invoke-MetasysFindObject {
     $deviceResponse = Invoke-MetasysMethod -Method Get `
         -Path /networkDevices?classification=device -ReturnBodyAsObject
 
+    if ($deviceResponse.items.Count -eq 0) {
+        $deviceResponse = Invoke-MetasysMethod -Method Get `
+            -Path /networkDevices?classification=server -ReturnBodyAsObject
+    }
+
+    if ($deviceResponse.items.Count -eq 0) {
+        return
+    }
+
     $firstDevice = $deviceResponse.items[0]
     $firstDeviceId = $firstDevice.id
 
     $matchingObjects = (Invoke-MetasysMethod -Method Get `
-        -Path /objects/$firstDeviceId/objects?objectType=$ObjectType`&flatten=true `
-        -ReturnBodyAsObject) | Select-Object -ExpandProperty items `
-        | Where-Object objectType -EQ $ObjectType
+            -Path /objects/$firstDeviceId/objects?objectType=$ObjectType`&flatten=true `
+            -ReturnBodyAsObject) | Select-Object -ExpandProperty items `
+    | Where-Object objectType -EQ $ObjectType
 
-    $matchingObjects | Select-Object -Property id, name, itemReference
+    $result = $matchingObjects | Select-Object -Property id, name, itemReference
+
+    $metasysHost = [MetasysEnvVars]::getSiteHost()
+    CacheObjectIds -MetasysHost $metasysHost -Objects $result
+
+    $result
 
 }
 

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -230,11 +230,11 @@ function Invoke-MetasysMethod {
                     $refreshRequest = buildRequest -uri $uri -token ([MetasysEnvVars]::getToken()) -skipCertificateCheck:$SkipCertificateCheck
 
                     try {
-                        Write-Information -Message "Attempting to refresh access token"
+                        Write-Debug "Attempting to refresh access token"
                         $refreshResponse = Invoke-RestMethod @refreshRequest
                         [MetasysEnvVars]::setExpires($refreshResponse.expires)
                         [MetasysEnvVars]::setTokenAsPlainText($refreshResponse.accessToken)
-                        Write-Information -Message "Refresh token successful"
+                        Write-Debug "Refresh token successful"
                     }
                     catch {
                         Write-Debug "Error attempting to refresh token"
@@ -262,7 +262,7 @@ function Invoke-MetasysMethod {
         $response = $null
         $responseObject = $null
 
-        Write-Information -Message "Attempting request"
+        Write-Debug "Attempting request"
 
         try {
             $responseObject = Invoke-WebRequest @request -SkipHttpErrorCheck

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -191,8 +191,13 @@ function Invoke-MetasysMethod {
 
         If ($Version -eq "") {
             # Use the version from last cma call, else the default api version (if set), else latest version
-            $Version = $env:METASYS_VERSION ?? (Get-MetasysDefaultApiVersion) ?? (Get-MetasysLatestVersion)
-            Write-Information "No version specified. Defaulting to v$Version"
+            if ($env:METASYS_VERSION) {
+                $Version = $env:METASYS_VERSION
+            }
+            else {
+                $Version = (Get-MetasysDefaultApiVersion) ?? (Get-MetasysLatestVersion)
+                Write-Information "No version specified. Defaulting to v$Version"
+            }
         }
 
         # Login Region

--- a/src/MetasysRestClient/Invoke-MetasysReadAttribute.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysReadAttribute.Tests.ps1
@@ -308,4 +308,41 @@ Describe "Invoke-MetasysReadAttribute" -Tag Unit {
             (Get-Alias -Name ira).Definition | Should -Be 'Invoke-MetasysReadAttribute'
         }
     }
+
+    Describe "Parameter defaults and positional binding" {
+
+        BeforeAll {
+            SetupConnectedSession
+            $objectId = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+            $responseBody = CreateReadAttributeResponse -AttributeId "presentValue" -Value 42.0
+
+            Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                [PSCustomObject]@{
+                    Content           = $responseBody
+                    StatusCode        = 200
+                    StatusDescription = "OK"
+                    Headers           = @{ "Content-Type" = "application/json" }
+                }
+            }
+        }
+
+        It "AttributeId defaults to presentValue when omitted" {
+            Invoke-MetasysReadAttribute -ObjectId $objectId
+
+            Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                $Uri.ToString() -like "*/attributes/presentValue*"
+            } -Exactly -Times 1 -Scope It
+        }
+
+        It "ItemReference is positional at position 0" {
+            Mock GetObjectId -ModuleName MetasysRestClient { $objectId }
+
+            # Pass ItemReference positionally — no parameter name
+            Invoke-MetasysReadAttribute "site:device.AHU-1"
+
+            Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                $Uri.ToString() -like "*/attributes/presentValue*"
+            } -Exactly -Times 1 -Scope It
+        }
+    }
 }

--- a/src/MetasysRestClient/Invoke-MetasysReadAttribute.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysReadAttribute.Tests.ps1
@@ -128,7 +128,7 @@ Describe "Invoke-MetasysReadAttribute" -Tag Unit {
             }
         }
 
-        Context "Attribute has non-normal conditions" {
+        Context "Attribute has non-normal conditions (reliability)" {
 
             BeforeAll {
                 $objectId = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
@@ -158,6 +158,44 @@ Describe "Invoke-MetasysReadAttribute" -Tag Unit {
                 Should -Invoke Write-Warning -ModuleName MetasysRestClient -ParameterFilter {
                     $Message -like "*$attributeId*non-normal conditions*"
                 } -Exactly -Times 1 -Scope Context
+            }
+        }
+
+        Context "Attribute has only a priority condition" {
+
+            BeforeAll {
+                $objectId = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+                $attributeId = "presentValue"
+                $condition = @{
+                    presentValue = @{
+                        priority = "writePriorityEnumSet.priorityDefault"
+                    }
+                }
+                $responseBody = CreateReadAttributeResponse -AttributeId $attributeId -Value 23.3 -Condition $condition
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        Content           = $responseBody
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                    }
+                }
+
+                Mock Write-Warning -ModuleName MetasysRestClient
+                Mock Write-Information -ModuleName MetasysRestClient
+
+                Invoke-MetasysReadAttribute -ObjectId $objectId -AttributeId $attributeId
+            }
+
+            It "Should write an Information message (not a warning) about the priority condition" {
+                Should -Invoke Write-Information -ModuleName MetasysRestClient -ParameterFilter {
+                    $MessageData -like "*$attributeId*non-normal conditions*priority*"
+                } -Exactly -Times 1 -Scope Context
+            }
+
+            It "Should not write a warning for a priority-only condition" {
+                Should -Invoke Write-Warning -ModuleName MetasysRestClient -Exactly -Times 0 -Scope Context
             }
         }
     }

--- a/src/MetasysRestClient/Invoke-MetasysReadAttribute.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysReadAttribute.Tests.ps1
@@ -1,0 +1,311 @@
+Set-StrictMode -Version 3
+
+BeforeAll {
+    $mod = Import-Module -Name ./ -Force -PassThru
+
+    Set-Variable -Name LatestVersion -Value (Get-MetasysLatestVersion) -Option Constant
+
+    function CreateReadAttributeResponse {
+        param(
+            [string]$AttributeId,
+            [object]$Value,
+            [string]$MetasysType = "float",
+            [hashtable]$Condition = @{}
+        )
+        $conditionJson = $Condition | ConvertTo-Json -Compress
+        @"
+{
+    "item": {
+        "$AttributeId": $($Value | ConvertTo-Json)
+    },
+    "condition": $conditionJson,
+    "schema": {
+        "type": "object",
+        "properties": {
+            "$AttributeId": {
+                "metasysType": "$MetasysType",
+                "type": "number"
+            }
+        }
+    }
+}
+"@
+    }
+
+    function CreateWebResponse {
+        param(
+            [string]$Body,
+            [int]$StatusCode = 200,
+            [string]$StatusDescription = "OK"
+        )
+        $response = [Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject]::new()
+        $headers = [System.Collections.Generic.Dictionary[string, System.Collections.Generic.IEnumerable[string]]]::new()
+        $headers["Content-Type"] = [string[]]@("application/json; charset=utf-8")
+        $bodyBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
+        $response.GetType().GetField("_content", [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance).SetValue($response, $bodyBytes)
+        $response.GetType().GetField("_statusCode", [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance).SetValue($response, [System.Net.HttpStatusCode]$StatusCode)
+        $response.GetType().GetField("_statusDescription", [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance).SetValue($response, $StatusDescription)
+        $response.GetType().GetField("_headers", [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance).SetValue($response, $headers)
+        $response
+    }
+
+    function SetupConnectedSession {
+        Clear-MetasysEnvVariables
+        $env:METASYS_ACCESS_TOKEN = (ConvertTo-SecureString -AsPlainText "test-token") | ConvertFrom-SecureString
+        $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
+        $env:METASYS_HOST = "oas12"
+        $env:METASYS_VERSION = $LatestVersion
+    }
+}
+
+Describe "Invoke-MetasysReadAttribute" -Tag Unit {
+
+    Describe "Read by ObjectId" {
+
+        BeforeAll {
+            SetupConnectedSession
+        }
+
+        Context "Successful read of a float attribute" {
+
+            BeforeAll {
+                $objectId = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+                $attributeId = "presentValue"
+                $expectedValue = 68.5
+                $responseBody = CreateReadAttributeResponse -AttributeId $attributeId -Value $expectedValue -MetasysType "float"
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        Content           = $responseBody
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                    }
+                }
+
+                $script:result = Invoke-MetasysReadAttribute -ObjectId $objectId -AttributeId $attributeId
+            }
+
+            It "Should call the correct API endpoint" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $Uri.ToString() -like "*/objects/$objectId/attributes/$attributeId*includeSchema=true*"
+                } -Exactly -Times 1 -Scope Context
+            }
+
+            It "Should return the attribute value" {
+                $script:result | Should -Be $expectedValue
+            }
+
+            It "Should use GET method" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $Method -eq "Get"
+                } -Exactly -Times 1 -Scope Context
+            }
+        }
+
+        Context "Successful read of a string attribute" {
+
+            BeforeAll {
+                $objectId = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+                $attributeId = "name"
+                $expectedValue = "AHU-1"
+                $responseBody = CreateReadAttributeResponse -AttributeId $attributeId -Value $expectedValue -MetasysType "string"
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        Content           = $responseBody
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                    }
+                }
+
+                $script:result = Invoke-MetasysReadAttribute -ObjectId $objectId -AttributeId $attributeId
+            }
+
+            It "Should return the string value" {
+                $script:result | Should -Be $expectedValue
+            }
+        }
+
+        Context "Attribute has non-normal conditions" {
+
+            BeforeAll {
+                $objectId = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+                $attributeId = "presentValue"
+                $condition = @{
+                    presentValue = @{
+                        reliability = "reliabilityEnumSet.noSensorConnected"
+                    }
+                }
+                $responseBody = CreateReadAttributeResponse -AttributeId $attributeId -Value 0.0 -Condition $condition
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        Content           = $responseBody
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                    }
+                }
+
+                Mock Write-Warning -ModuleName MetasysRestClient
+
+                Invoke-MetasysReadAttribute -ObjectId $objectId -AttributeId $attributeId
+            }
+
+            It "Should write a warning about non-normal conditions" {
+                Should -Invoke Write-Warning -ModuleName MetasysRestClient -ParameterFilter {
+                    $Message -like "*$attributeId*non-normal conditions*"
+                } -Exactly -Times 1 -Scope Context
+            }
+        }
+    }
+
+    Describe "Read by ItemReference" {
+
+        BeforeAll {
+            SetupConnectedSession
+        }
+
+        Context "ObjectId found in cache (no API call for ID lookup)" {
+
+            BeforeAll {
+                $itemReference = "site:device.AHU-1"
+                $cachedObjectId = "ba1a703a-1e96-54ae-9ae6-9590a55c2e4a"
+                $attributeId = "presentValue"
+                $expectedValue = 72.0
+                $responseBody = CreateReadAttributeResponse -AttributeId $attributeId -Value $expectedValue
+
+                Mock GetObjectId -ModuleName MetasysRestClient { $cachedObjectId }
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        Content           = $responseBody
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                    }
+                }
+
+                $script:result = Invoke-MetasysReadAttribute -ItemReference $itemReference -AttributeId $attributeId
+            }
+
+            It "Should look up object ID from cache" {
+                Should -Invoke GetObjectId -ModuleName MetasysRestClient -ParameterFilter {
+                    $ItemReference -eq "site:device.AHU-1"
+                } -Exactly -Times 1 -Scope Context
+            }
+
+            It "Should not call identifiers endpoint" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $Uri.ToString() -like "*identifiers*"
+                } -Exactly -Times 0 -Scope Context
+            }
+
+            It "Should call attribute endpoint with cached ObjectId" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $Uri.ToString() -like "*/objects/$cachedObjectId/attributes/$attributeId*"
+                } -Exactly -Times 1 -Scope Context
+            }
+
+            It "Should return the attribute value" {
+                $script:result | Should -Be $expectedValue
+            }
+        }
+
+        Context "ObjectId not in cache - resolved via API and then cached" {
+
+            BeforeAll {
+                $itemReference = "site:device.AHU-1"
+                $resolvedObjectId = "cc2b814a-2f07-65bf-0bf7-a661c5bd3f5b"
+                $attributeId = "presentValue"
+                $expectedValue = 55.0
+                $responseBody = CreateReadAttributeResponse -AttributeId $attributeId -Value $expectedValue
+
+                Mock GetObjectId -ModuleName MetasysRestClient { $null }
+                Mock CacheObjectId -ModuleName MetasysRestClient
+
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    param($Uri)
+                    if ($Uri.ToString() -like "*identifiers*") {
+                        [PSCustomObject]@{
+                            Content           = "`"$resolvedObjectId`""
+                            StatusCode        = 200
+                            StatusDescription = "OK"
+                            Headers           = @{ "Content-Type" = "application/json" }
+                        }
+                    }
+                    else {
+                        [PSCustomObject]@{
+                            Content           = $responseBody
+                            StatusCode        = 200
+                            StatusDescription = "OK"
+                            Headers           = @{ "Content-Type" = "application/json" }
+                        }
+                    }
+                }
+
+                $script:result = Invoke-MetasysReadAttribute -ItemReference $itemReference -AttributeId $attributeId
+            }
+
+            It "Should call identifiers endpoint to resolve the ItemReference" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $Uri.ToString() -like "*identifiers*fqr=$itemReference*"
+                } -Exactly -Times 1 -Scope Context
+            }
+
+            It "Should cache the resolved ObjectId" {
+                Should -Invoke CacheObjectId -ModuleName MetasysRestClient -ParameterFilter {
+                    $ItemReference -eq $itemReference -and $ObjectId -eq $resolvedObjectId
+                } -Exactly -Times 1 -Scope Context
+            }
+
+            It "Should return the attribute value" {
+                $script:result | Should -Be $expectedValue
+            }
+        }
+
+        Context "ItemReference not found" {
+
+            BeforeAll {
+                # Clear the cache to ensure GetObjectId returns null without needing a mock.
+                # This avoids any stale cache state on the developer's machine.
+                Remove-MetasysCache -MetasysHost "oas12"
+
+                # The real identifiers API returns a JSON object (not a bare string) when
+                # the reference can't be resolved. Return a non-string body so that
+                # Invoke-MetasysMethod returns a Hashtable, which fails the
+                # non-string guard in Invoke-MetasysReadAttribute.
+                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        Content           = '{"httpCode":400,"message":"Object not found"}'
+                        StatusCode        = 400
+                        StatusDescription = "Bad Request"
+                        Headers           = @{ "Content-Type" = "application/json" }
+                    }
+                }
+
+                Invoke-MetasysReadAttribute -ItemReference "site:device.DoesNotExist" -AttributeId "presentValue" `
+                    -ErrorAction SilentlyContinue -ErrorVariable script:capturedErrors
+            }
+
+            It "Should report an error that the reference was not found" {
+                $script:capturedErrors[0].Exception.Message | Should -BeLike "*not found*"
+            }
+
+            It "Should not attempt to read the attribute" {
+                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $Uri.ToString() -like "*/attributes/*"
+                } -Exactly -Times 0 -Scope Context
+            }
+        }
+    }
+
+    Describe "Alias" {
+
+        It "Should have an alias 'ira'" {
+            (Get-Alias -Name ira).Definition | Should -Be 'Invoke-MetasysReadAttribute'
+        }
+    }
+}

--- a/src/MetasysRestClient/MetasysRestClient.psd1
+++ b/src/MetasysRestClient/MetasysRestClient.psd1
@@ -8,7 +8,9 @@
     # Script module or binary module file associated with this manifest.
     RootModule           = 'Invoke-MetasysMethod.psm1'
 
-    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1", "Read-ConfigFile.ps1", "constants.ps1", "preferences.ps1", "Invoke-MetasysGetStream.ps1", "event-parser.ps1", "Invoke-FindObject.ps1")
+    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1",
+        "Read-ConfigFile.ps1", "constants.ps1", "preferences.ps1", "Invoke-MetasysGetStream.ps1", "event-parser.ps1", "Invoke-FindObject.ps1",
+        "operations.ps1", "metasys-value.ps1", "completers.ps1")
 
     # Version number of this module.
     ModuleVersion        = '2.4.0'
@@ -32,7 +34,7 @@
     Description          = 'Interact with a Metasys site through Metasys REST API'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion    = '7.0.0'
+    PowerShellVersion    = '7.2.0'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''
@@ -53,7 +55,7 @@
     # RequiredModules = @()
 
     # Assemblies that must be loaded prior to importing this module
-    # RequiredAssemblies = @()
+    RequiredAssemblies   = @('System.Text.Json.dll')
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     # ScriptsToProcess = @()
@@ -73,7 +75,9 @@
     'Get-LastMetasysHeadersAsObject', 'Clear-MetasysEnvVariables', 'Connect-MetasysAccount', 'Get-MetasysLatestVersion', 'Set-MetasysDefaultApiVersion', 'Get-MetasysDefaultApiVersion',
     'Set-MetasysSkipSecureCheckNotSecure', 'Reset-MetasysSkipSecureCheckNotSecure',
     'Invoke-MetasysGetStream', 'Invoke-MetasysFindObject',
-    'Set-MetasysAccessToken'
+    'Set-MetasysAccessToken',
+    "Get-MetasysCachedItemReferences", "Get-MetasysCachedObjectIds", 'Remove-MetasysCache', 'Invoke-MetasysDiscoverObjects',
+    'Invoke-MetasysReadAttribute'
 
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
@@ -83,7 +87,7 @@
     VariablesToExport    = @()
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport      = 'imm', 'cma', 'ims', 'ifo'
+    AliasesToExport      = 'imm', 'cma', 'ims', 'ifo', 'ira'
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/src/MetasysRestClient/completers.ps1
+++ b/src/MetasysRestClient/completers.ps1
@@ -32,7 +32,7 @@ function Get-MetasysCachedObjectIds {
         $commandAst,
         $fakeBoundParameters )
 
-    $cache = GetCacheObject -MetasysHost ([MetasysEnvVars]::getSiteHost()) | ConvertFrom-Json -AsHashtable
+    $cache = GetCacheObject -MetasysHost ([MetasysEnvVars]::getSiteHost())
 
     foreach ($reference in $cache.Keys) {
         $id = $cache[$reference]
@@ -40,6 +40,16 @@ function Get-MetasysCachedObjectIds {
             [System.Management.Automation.CompletionResult]::new($id, "$id, $reference", [System.Management.Automation.CompletionResultType]::ParameterValue, $id)
         }
     }
+}
+
+Register-ArgumentCompleter -CommandName "Invoke-MetasysReadAttribute" -ParameterName "ItemReference" -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    Get-MetasysCachedItemReferences $commandName $parameterName $wordToComplete $commandAst $fakeBoundParameters
+}
+
+Register-ArgumentCompleter -CommandName "Invoke-MetasysReadAttribute" -ParameterName "ObjectId" -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    Get-MetasysCachedObjectIds $commandName $parameterName $wordToComplete $commandAst $fakeBoundParameters
 }
 
 Export-ModuleMember -Function "Get-MetasysCachedItemReferences", "Get-MetasysCachedObjectIds"

--- a/src/MetasysRestClient/completers.ps1
+++ b/src/MetasysRestClient/completers.ps1
@@ -1,0 +1,45 @@
+function Get-MetasysCachedItemReferences {
+    param ( $commandName,
+        $parameterName,
+        $wordToComplete,
+        $commandAst,
+        $fakeBoundParameters )
+
+    $cache = GetCacheObject -MetasysHost ([MetasysEnvVars]::getSiteHost())
+
+    $quotesNeeded = $false
+    foreach ($reference in $cache.Keys) {
+        if ($reference.Contains(" ")) {
+            $quotesNeeded = $true
+            break
+        }
+    }
+
+    foreach ($reference in $cache.Keys) {
+        if ($reference -like "*$wordToComplete*") {
+            if ($quotesNeeded) {
+                $reference = "`"$reference`""
+            }
+            [System.Management.Automation.CompletionResult]::new($reference, $reference, [System.Management.Automation.CompletionResultType]::ParameterValue, $reference)
+        }
+    }
+}
+
+function Get-MetasysCachedObjectIds {
+    param ( $commandName,
+        $parameterName,
+        $wordToComplete,
+        $commandAst,
+        $fakeBoundParameters )
+
+    $cache = GetCacheObject -MetasysHost ([MetasysEnvVars]::getSiteHost()) | ConvertFrom-Json -AsHashtable
+
+    foreach ($reference in $cache.Keys) {
+        $id = $cache[$reference]
+        if ($id -like "$wordToComplete*") {
+            [System.Management.Automation.CompletionResult]::new($id, "$id, $reference", [System.Management.Automation.CompletionResultType]::ParameterValue, $id)
+        }
+    }
+}
+
+Export-ModuleMember -Function "Get-MetasysCachedItemReferences", "Get-MetasysCachedObjectIds"

--- a/src/MetasysRestClient/metasys-value.ps1
+++ b/src/MetasysRestClient/metasys-value.ps1
@@ -1,0 +1,430 @@
+using namespace System.Text.Json.Nodes
+
+
+function ParseMetasysValue {
+    param (
+        [JsonNode]$Value,
+        [JsonNode]$Schema
+    )
+
+    $metasysType = $Schema["metasysType"]
+    if ($null -eq $metasysType) {
+        return $null
+    }
+
+    switch ($metasysType) {
+        "none" { return [NoneValue]::Instance }
+        "bool" { return [BoolValue]::new($Value.GetValue[bool]()) }
+        "ulong" { return [ULongValue]::new($Value.GetValue[uint]()) }
+        "long" { return [LongValue]::new($Value.GetValue[int]()) }
+        "float" { return [FloatValue]::new($Value.GetValue[float]()) }
+        "double" { return [DoubleValue]::new($Value.GetValue[double]()) }
+        "octetString" { return [OctetStringValue]::Parse($Value.GetValue[string]()) }
+        "string" { return [StringValue]::new($Value.GetValue[string]()) }
+        "bitString" { return [BitStringValue]::Parse($Value.GetValue[string]()) }
+        "enum" { return [EnumValue]::Parse($Value.GetValue[string]()) }
+        "enumMemberId" { return [EnumMemberIdValue]::new($Value.GetValue[uint]()) }
+        default { return [NoneValue]::Instance }
+    }
+}
+
+
+class MetasysValue {
+
+    [object]$Value
+
+    # Parse a read attribute response
+    static [MetasysValue] ParseReadAttributeResponse([string]$readAttributeResponse) {
+        $response = [JsonNode]::Parse($readAttributeResponse)
+
+
+        # We expect a single property with a schema for that property
+        $item = $response["item"]
+        $enumerator = $item.GetEnumerator()
+        if ($enumerator.MoveNext()) {
+            $attributeName = $enumerator.Current.Key
+            $attributeValueNode = $enumerator.Current.Value
+        }
+        else {
+            throw "No attribute value found"
+        }
+
+        $attributeSchema = $response["schema"]["properties"][$attributeName]
+        return ParseMetasysValue -Value $attributeValueNode -Schema $attributeSchema
+    }
+}
+
+<#
+.SYNOPSIS
+    Represents an instance of the None data type
+#>
+class NoneValue : MetasysValue {
+    <#
+        .SYNOPSIS
+            Represents the one and only instance of None
+    #>
+    static [NoneValue]$Instance = [NoneValue]::new()
+}
+
+class BoolValue : MetasysValue {
+    hidden [bool] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'BoolValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    BoolValue([bool]$value) {
+        $this._value = $value;
+        $Definition = [BoolValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [bool] ToBoolean() {
+        return $this._value
+    }
+
+    [string] ToString() {
+        return $this._value.ToString()
+    }
+}
+
+<#
+.SYNOPSIS
+    Represents a 32-bit unsigned integer
+#>
+class ULongValue : MetasysValue {
+    hidden [uint] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'ULongValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    ULongValue([uint]$value) {
+        $this._value = $value;
+        $Definition = [ULongValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [uint] ToUInt32() {
+        return $this._value
+    }
+
+    [string] ToString() {
+        return $this._value.ToString()
+    }
+}
+
+
+<#
+.SYNOPSIS
+    Represents a 32-bit signed integer
+#>
+class LongValue : MetasysValue {
+    hidden [int] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'LongValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    LongValue([int]$value) {
+        $this._value = $value;
+        $Definition = [LongValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [int] ToInt32() {
+        return $this._value
+    }
+
+    [string] ToString() {
+        return $this._value.ToString()
+    }
+}
+
+
+<#
+.SYNOPSIS
+    Represents a 32-bit floating point number
+#>
+class FloatValue : MetasysValue {
+    hidden [float] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'FloatValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    FloatValue([float]$value) {
+        $this._value = $value;
+        $Definition = [FloatValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [float] ToFloat() {
+        return $this._value
+    }
+
+    [string] ToString() {
+        return $this._value.ToString()
+    }
+}
+
+
+
+<#
+.SYNOPSIS
+    Represents a 64-bit floating point number
+#>
+class DoubleValue : MetasysValue {
+    hidden [double] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'DoubleValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    DoubleValue([double]$value) {
+        $this._value = $value;
+        $Definition = [DoubleValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [double] ToDouble() {
+        return $this._value
+    }
+
+    [string] ToString() {
+        return $this._value.ToString()
+    }
+}
+
+
+
+<#
+.SYNOPSIS
+    Represents an array of bytes
+#>
+class OctetStringValue : MetasysValue {
+    hidden [byte[]] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'OctetStringValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return [byte[]]$this._value
+        }
+    }
+
+    OctetStringValue([byte[]]$value) {
+        $this._value = $value;
+        $Definition = [OctetStringValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [string] ToString() {
+        return $this._value.ToString()
+    }
+
+    static [OctetStringValue] Parse([string]$HexString) {
+        # Calculate the number of bytes
+        $byteCount = $HexString.Length / 2
+
+        # Initialize the byte array with the calculated size
+        [byte[]]$byteArray = New-Object byte[] $byteCount
+
+        # Loop through the hex string in pairs of characters
+        for ($i = 0; $i -lt $byteCount; $i++) {
+            # Extract a pair of characters
+            $hexPair = $HexString.Substring($i * 2, 2)
+
+            # Convert the hex pair to a byte and assign it to the array
+            $byteArray[$i] = [Convert]::ToByte($hexPair, 16)
+        }
+
+        # Output the byte array
+        return [OctetStringValue]::new($byteArray)
+
+    }
+}
+
+
+<#
+.SYNOPSIS
+    Represents a string
+#>
+class StringValue : MetasysValue {
+    hidden [string] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'StringValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    StringValue([string]$value) {
+        $this._value = $value;
+        $Definition = [StringValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [string] ToString() {
+        return $this._value
+    }
+}
+
+
+class BitStringValue : MetasysValue {
+    hidden [string] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'BitStringValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    BitStringValue([bool[]]$bits) {
+        $stringValue = $bits | ForEach-Object { if ($_) { "1" } else { "0" } }
+        $this.Initialize($stringValue)
+    }
+
+    hidden BitStringValue([string]$value) {
+        $this.Initialize($value)
+    }
+
+    static [BitStringValue] Parse([string]$value) {
+        $value.ToCharArray() | ForEach-Object {
+            if ($_ -notin "0", "1") {
+                throw "$_ is an illegal character in a BitString"
+            }
+        }
+        return [BitStringValue]::new($value)
+    }
+
+    hidden [void]Initialize([string]$value) {
+        $this._value = $value;
+        $Definition = [BitStringValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [string] ToString() {
+        return $this._value
+    }
+
+    [bool[]] ToBools() {
+        return $this._value.ToCharArray() | ForEach-Object { if ($_ -eq "1") { $true } else { $false } }
+    }
+}
+
+
+<#
+.SYNOPSIS
+    Represents an enumerated value
+#>
+class EnumValue : MetasysValue {
+    hidden [string] $_set
+    hidden [string] $_member
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'EnumValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return "$($this._set).$($this._member)"
+        }
+    }
+
+    hidden static $SetDefinition = @{
+        TypeName   = 'EnumValue'
+        MemberName = 'Set'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._set
+        }
+    }
+
+    hidden static $MemberDefinition = @{
+        TypeName   = 'EnumValue'
+        MemberName = 'Member'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._member
+        }
+    }
+
+    EnumValue([string]$set, [string]$member) {
+        $this._set = $set
+        $this._member = $member
+        $VDefinition = [EnumValue]::ValueDefinition
+        $SDefinition = [EnumValue]::SetDefinition
+        $MDefinition = [EnumValue]::MemberDefinition
+        Update-TypeData @VDefinition
+        Update-TypeData @SDefinition
+        Update-TypeData @MDefinition
+    }
+
+    static [EnumValue] Parse([string]$value) {
+        $parts = $value.Split(".")
+        if ($parts.Count -ne 2) {
+            throw "Invalid enum value"
+        }
+        return [EnumValue]::new($parts[0], $parts[1])
+    }
+
+
+    [string] ToString() {
+        return $this.Value
+    }
+}
+
+class EnumMemberIdValue : MetasysValue {
+    hidden [uint] $_value
+
+    hidden static $ValueDefinition = @{
+        TypeName   = 'EnumMemberIdValue'
+        MemberName = 'Value'
+        MemberType = 'ScriptProperty'
+        Value      = {
+            return $this._value
+        }
+    }
+
+    EnumMemberIdValue([uint]$value) {
+        $this._value = $value;
+        $Definition = [EnumMemberIdValue]::ValueDefinition
+        Update-TypeData @Definition
+    }
+
+    [string] ToString() {
+        return $this._value.ToString()
+    }
+}

--- a/src/MetasysRestClient/operations.ps1
+++ b/src/MetasysRestClient/operations.ps1
@@ -123,22 +123,57 @@ function Remove-MetasysCache {
 function Invoke-MetasysReadAttribute {
     <#
     .SYNOPSIS
-        Read the specified attribute of the specified object
+        Read the specified attribute of the specified object.
 
     .DESCRIPTION
-        This function calls the get attribute value operation using the object id and
-        attribute id specified.
+        Reads a single attribute value from a Metasys object and returns it to the pipeline.
+
+        The object may be identified by object ID (-ObjectId) or by fully-qualified item reference
+        (-ItemReference). When using -ItemReference, the resolved object ID is cached locally
+        so subsequent calls for the same reference skip the lookup API call.
+
+        AttributeId defaults to 'presentValue' when not specified.
+
+        Non-normal conditions on the attribute are reported after the value:
+          - A WARNING is written if the condition indicates something unexpected (e.g. reliability fault).
+          - An INFORMATION message is written if the only condition is a non-default write priority.
+            To see these messages, pass -InformationAction Continue or set
+            $InformationPreference = 'Continue'.
+
+    .PARAMETER ObjectId
+        The object ID of the Metasys object to read from.
+
+    .PARAMETER ItemReference
+        The fully-qualified item reference (e.g. site:device.AV1) of the object to read from.
+        Tab completion is available from the local object ID cache.
+
+    .PARAMETER AttributeId
+        The attribute to read. Defaults to 'presentValue'.
 
     .OUTPUTS
-        System.String
-            The payloads from Metasys are formatted JSON strings. This is the default return type for this function.
+        The attribute value (type depends on the Metasys data type of the attribute).
 
     .EXAMPLE
-        Invoke-MetasysReadAttribute -ObjectId ba1a703a-1e96-54ae-9ae6-9590a55c2e4a -AttributeId name
+        Invoke-MetasysReadAttribute -ObjectId ba1a703a-1e96-54ae-9ae6-9590a55c2e4a
 
-        This will read the attribute `name` of the object and return its value.
+        Reads the presentValue of the object with the given object ID.
 
-        MOLEX LIGHT POWER
+    .EXAMPLE
+        ira welch12:welch12/AV1
+
+        Reads the presentValue using the item reference. The alias 'ira' and positional
+        parameter binding mean you can type this immediately after 'ira <Tab>'.
+
+    .EXAMPLE
+        ira welch12:welch12/AV1 -AttributeId name
+
+        Reads the 'name' attribute of the object.
+
+    .EXAMPLE
+        ira welch12:welch12/AV1 -InformationAction Continue
+
+        Reads presentValue and also displays informational messages such as a non-default
+        write priority condition.
 
     #>
     [CmdletBinding(PositionalBinding = $false)]

--- a/src/MetasysRestClient/operations.ps1
+++ b/src/MetasysRestClient/operations.ps1
@@ -145,11 +145,11 @@ function Invoke-MetasysReadAttribute {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = "ObjectId")]
         [string]$ObjectId,
-        [Parameter(Mandatory = $true, ParameterSetName = "ItemReference")]
+        [Parameter(Mandatory = $true, ParameterSetName = "ItemReference", Position = 0)]
         [string]$ItemReference,
 
-        [Parameter(Mandatory = $true)]
-        [String]$AttributeId
+        [Parameter(Mandatory = $false)]
+        [String]$AttributeId = "presentValue"
     )
 
     $shouldReadAttribute = $true

--- a/src/MetasysRestClient/operations.ps1
+++ b/src/MetasysRestClient/operations.ps1
@@ -183,7 +183,15 @@ function Invoke-MetasysReadAttribute {
         $responseParsed = $response | ConvertFrom-Json -AsHashtable -Depth 20
 
         if (([System.Management.Automation.OrderedHashtable]$responseParsed.condition).ContainsKey($AttributeId)) {
-            Write-Warning ("$AttributeId has non-normal conditions $(ConvertTo-Json $responseParsed.condition[$AttributeId])")
+            $conditionDetail = $responseParsed.condition[$AttributeId]
+            $conditionKeys = @($conditionDetail.Keys)
+            $message = "$AttributeId has non-normal conditions $(ConvertTo-Json $conditionDetail)"
+            if ($conditionKeys.Count -eq 1 -and $conditionKeys[0] -eq "priority") {
+                Write-Information $message
+            }
+            else {
+                Write-Warning $message
+            }
         }
     }
 }

--- a/src/MetasysRestClient/operations.ps1
+++ b/src/MetasysRestClient/operations.ps1
@@ -1,0 +1,258 @@
+
+function GetCachePath {
+    param (
+        [string]$MetasysHost
+    )
+    # Determine the cache directory based on the OS
+    $CacheDirName = "MetasysRestClient"
+    if ($IsWindows) {
+        $cacheDir = [System.IO.Path]::Combine($env:LOCALAPPDATA, $CacheDirName)
+    }
+    elseif ($IsLinux) {
+        $cacheDir = [System.IO.Path]::Combine($env:HOME, ".cache", $CacheDirName)
+    }
+    elseif ($IsMacOS) {
+        $cacheDir = [System.IO.Path]::Combine($env:HOME, "Library", "Caches", $CacheDirName)
+    }
+    else {
+        throw "Unsupported OS"
+    }
+
+    # Create the cache directory if it doesn't exist
+    if (-not (Test-Path -Path $cacheDir)) {
+        New-Item -ItemType Directory -Path $cacheDir | Out-Null
+    }
+
+    # Create a file in the cache directory
+    $filePath = [System.IO.Path]::Combine($cacheDir, "$MetasysHost-cachedObjectIds.json")
+    if (-not (Test-Path -Path $filePath)) {
+        New-Item -ItemType File -Path $filePath -Force | Out-Null
+    }
+
+    return $filePath
+}
+
+function LookupCachedReferences {
+    param(
+        [string]$wordToComplete,
+        [System.Management.Automation.Language.CommandAst]$commandAst,
+        [int]$cursorPosition,
+        [System.Management.Automation.CommandCompletionOptions]$options,
+        [System.Management.Automation.Language.Ast]$fakeBoundParameters
+    )
+
+    $metasysHost = [MetasysEnvVars]::getSiteHost()
+    $cache = GetCacheObject -MetasysHost $metasysHost
+    $cache.Keys
+}
+
+function GetCacheObject {
+    param (
+        [string]$MetasysHost
+    )
+    $cacheFile = GetCachePath -MetasysHost $MetasysHost
+
+    $cacheContents = ([System.IO.File]::ReadAllText($cacheFile)).Trim()
+
+    $cache = if ($cacheContents -eq "") {
+        @{}
+    }
+    else {
+        $cacheContents | ConvertFrom-Json -AsHashtable
+    }
+
+    $cache
+}
+
+function GetObjectId {
+    param (
+        [string]$MetasysHost,
+        [string]$ItemReference
+    )
+    $cache = GetCacheObject -MetasysHost $MetasysHost
+    $cache[$ItemReference]
+}
+
+function CacheObjectIds {
+    param (
+        [string]$MetasysHost,
+        # It is expected that every object has an `id` and `itemReference`
+        [Array]$Objects
+    )
+
+    $cache = GetCacheObject -MetasysHost $MetasysHost
+    $cacheFile = GetCachePath -MetasysHost $MetasysHost
+
+    foreach ($object in $Objects) {
+        $cache[$object.itemReference] = $object.id
+    }
+
+    [System.IO.File]::WriteAllText($cacheFile, (ConvertTo-Json -InputObject $cache))
+
+}
+
+function CacheObjectId {
+    param (
+        [string]$MetasysHost,
+        [string]$ItemReference,
+        [string]$ObjectId
+    )
+
+    $cache = GetCacheObject -MetasysHost $MetasysHost
+    $cacheFile = GetCachePath -MetasysHost $MetasysHost
+
+    $cache[$ItemReference] = $ObjectId
+
+    [System.IO.File]::WriteAllText($cacheFile, (ConvertTo-Json -InputObject $cache))
+}
+
+function Remove-MetasysCache {
+    param(
+        [string]$MetasysHost
+    )
+    $cachePath = GetCachePath -MetasysHost $MetasysHost
+    try {
+        Remove-Item -Path $cachePath -Force
+    }
+    catch {
+
+    }
+}
+
+
+function Invoke-MetasysReadAttribute {
+    <#
+    .SYNOPSIS
+        Read the specified attribute of the specified object
+
+    .DESCRIPTION
+        This function calls the get attribute value operation using the object id and
+        attribute id specified.
+
+    .OUTPUTS
+        System.String
+            The payloads from Metasys are formatted JSON strings. This is the default return type for this function.
+
+    .EXAMPLE
+        Invoke-MetasysReadAttribute -ObjectId ba1a703a-1e96-54ae-9ae6-9590a55c2e4a -AttributeId name
+
+        This will read the attribute `name` of the object and return its value.
+
+        MOLEX LIGHT POWER
+
+    #>
+    [CmdletBinding(PositionalBinding = $false)]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = "ObjectId")]
+        [string]$ObjectId,
+        [Parameter(Mandatory = $true, ParameterSetName = "ItemReference")]
+        [string]$ItemReference,
+
+        [Parameter(Mandatory = $true)]
+        [String]$AttributeId
+    )
+
+    $shouldReadAttribute = $true
+
+    if ($PSCmdlet.ParameterSetName -eq 'ItemReference') {
+        $MetasysHost = [MetasysEnvVars]::getSiteHost()
+        $ObjectId = GetObjectId -MetasysHost $MetasysHost -ItemReference $ItemReference
+
+        if ($null -eq $ObjectId -or $ObjectId -eq "") {
+
+            # Use a separate variable to avoid type coercion: $ObjectId is [string]-typed,
+            # so assigning an OrderedHashtable would silently coerce it to a string.
+            $identifiersResponse = imm "/objects/identifiers?fqr=$ItemReference" -ReturnBodyAsObject
+            if ($identifiersResponse -isnot [string]) {
+                Write-Error "The reference '$ItemReference' was not found."
+                $shouldReadAttribute = $false
+            }
+            else {
+                $ObjectId = $identifiersResponse
+                CacheObjectId -MetasysHost $MetasysHost -ItemReference $ItemReference -ObjectId $ObjectId
+            }
+        }
+    }
+
+    if ($shouldReadAttribute) {
+        $response = Invoke-MetasysMethod "/objects/$ObjectId/attributes/$AttributeId`?includeSchema=true"
+
+        $result = [MetasysValue]::ParseReadAttributeResponse($response)
+        $result.Value
+
+        $responseParsed = $response | ConvertFrom-Json -AsHashtable -Depth 20
+
+        if (([System.Management.Automation.OrderedHashtable]$responseParsed.condition).ContainsKey($AttributeId)) {
+            Write-Warning ("$AttributeId has non-normal conditions $(ConvertTo-Json $responseParsed.condition[$AttributeId])")
+        }
+    }
+}
+
+
+
+function Invoke-MetasysGetObjectView {
+    [CmdletBinding(PositionalBinding = $false)]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = "ObjectId")]
+        [string]$ObjectId,
+        [Parameter(Mandatory = $true, ParameterSetName = "ItemReference")]
+        [string]$ItemReference,
+        [Parameter(Mandatory = $false)]
+        [string]$View = $null
+    )
+    if ($PSCmdlet.ParameterSetName -eq 'ItemReference') {
+        $MetasysHost = [MetasysEnvVars]::getSiteHost()
+        $ObjectId = GetObjectId -MetasysHost $MetasysHost -ItemReference $ItemReference
+
+        if ($null -eq $ObjectId -or $ObjectId -eq "") {
+
+            $ObjectId = imm "/objects/identifiers?fqr=$ItemReference" -ReturnBodyAsObject
+            if ($null -eq $ObjectId -or $ObjectId.GetType().Name -ne "String") {
+                Write-Error "The reference '$ItemReference' was not found."
+                return
+            }
+            CacheObjectId -MetasysHost $MetasysHost -ItemReference $ItemReference -ObjectId $ObjectId
+        }
+    }
+
+    $viewPath = if ($View) { "?viewId=$View" } else { "" }
+
+    $path = "/objects/$ObjectId$viewPath"
+
+    $result = Invoke-MetasysMethod $path -ReturnBodyAsObject
+
+    if ($result.ContainsKey("item")) {
+        $result.item
+    }
+}
+
+
+function Invoke-MetasysDiscoverObjects {
+    param(
+        [ArgumentCompleter({ Get-MetasysCachedItemReferences @args })]
+        [string]$ItemReference
+    )
+    $metasysHost = [MetasysEnvVars]::getSiteHost()
+    $objectId = GetObjectId -MetasysHost $metasysHost -ItemReference $ItemReference
+    if ($null -eq $objectId) {
+        $objectId = Invoke-MetasysMethod -Path "/objects/identifiers?fqr=$ItemReference" -ReturnBodyAsObject
+    }
+
+    $objects = Invoke-MetasysMethod `
+        -Path "/objects/$objectId/objects?depth=-1`&flatten=true" `
+        -ReturnBodyAsObject | Select-Object -ExpandProperty items
+
+    CacheObjectIds -MetasysHost $metasysHost -Objects $objects
+
+    "Discovery complete. $($objects.Count) objects found."
+}
+
+
+
+Set-Alias -Name ira -Value Invoke-MetasysReadAttribute
+
+Export-ModuleMember -Function 'Invoke-MetasysReadAttribute'
+Export-ModuleMember -Alias 'ira'
+
+Export-ModuleMember -Function 'Remove-MetasysCache'
+Export-ModuleMember -Function 'Invoke-MetasysDiscoverObjects'


### PR DESCRIPTION
Adds a new `Invoke-MetasysReadAttribute` cmdlet (alias: `ira`) for reading a single attribute value from a Metasys object.

## Usage

```powershell
# By object ID
Invoke-MetasysReadAttribute -ObjectId <guid> -AttributeId presentValue

# By item reference (resolved via identifiers API and cached locally)
Invoke-MetasysReadAttribute -ItemReference site:device.AHU-1 -AttributeId presentValue

# Using the alias
ira -ItemReference site:device.AHU-1 -AttributeId presentValue
```

## Details

- Accepts either an object GUID (`-ObjectId`) or a fully-qualified item reference (`-ItemReference`); these are exclusive parameter sets.
- When given an item reference, resolves it to an object ID via `GET /objects/identifiers?fqr=` and caches the result locally so subsequent calls skip the lookup.
- Returns the attribute value directly to the pipeline.
- Emits a warning when the attribute has non-normal conditions.
- Reports a non-terminating error if the item reference cannot be resolved.
- Exports `Invoke-MetasysReadAttribute` and alias `ira` from the module manifest.
- Includes a full Pester test suite covering ObjectId reads, ItemReference resolution (cache hit, cache miss, not-found error), and the alias.