### PR TITLE
fix: stream large responses, handle binary output

### DIFF
--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -117,8 +117,10 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
                     $mockConsole.ReadHost($Prompt)
                 }
 
-                Mock Invoke-WebRequest -ModuleName MetasysRestClient {
-
+                Mock invokeHttpRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{ StatusCode = 200; StatusDescription = "OK"
+                        Headers = @{ "Content-Type" = "application/json" }
+                        Content = "{}"; ContentEncoding = $null }
                 }
 
                 Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient
@@ -133,8 +135,8 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             }
 
             It "Should prompt for Path,  and Invoke Operation" {
-                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient  -ParameterFilter {
-                    $Uri.ToString() -eq "https://$($env:METASYS_HOST)/api/v$LatestVersion" + "$($mockConsole.GetResponse([MockConsole]::PathPrompt))"
+                Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient  -ParameterFilter {
+                    $uri -eq "https://$($env:METASYS_HOST)/api/v$LatestVersion" + "$($mockConsole.GetResponse([MockConsole]::PathPrompt))"
                 } -Exactly -Times 1 -Scope Context
 
             }
@@ -146,14 +148,14 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
 
                 Mock Write-Error -ModuleName MetasysRestClient
 
-                Mock Invoke-WebRequest -ModuleName MetasysRestClient
+                Mock invokeHttpRequest -ModuleName MetasysRestClient
 
                 @( "body1", "body2" ) | Invoke-MetasysMethod -Method Post https://oas12/api/v4/objects -Version 3
 
             }
 
             It "Should exit BEGIN block and not enter PROCESS block" {
-                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times 0 -Scope Context
+                Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Exactly -Times 0 -Scope Context
             }
 
         }
@@ -162,7 +164,11 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
 
             It "Should use user preference for version if set" {
 
-                Mock Invoke-WebRequest -ModuleName MetasysRestClient
+                Mock invokeHttpRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{ StatusCode = 200; StatusDescription = "OK"
+                        Headers = @{ "Content-Type" = "application/json" }
+                        Content = "{}"; ContentEncoding = $null }
+                }
 
                 Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient
                 Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient {
@@ -171,8 +177,8 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
 
                 Invoke-MetasysMethod /objects
 
-                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -ParameterFilter {
-                    $Uri.ToString() -eq "https://$($env:METASYS_HOST)/api/v3/objects"
+                Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $uri -eq "https://$($env:METASYS_HOST)/api/v3/objects"
                 } -Exactly -Times 1 -Scope Context
 
             }
@@ -202,7 +208,11 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
         Context "An operation is invoked, but session is expired" {
             BeforeAll {
 
-                Mock Invoke-WebRequest -ModuleName MetasysRestClient
+                Mock invokeHttpRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{ StatusCode = 200; StatusDescription = "OK"
+                        Headers = @{ "Content-Type" = "application/json" }
+                        Content = "{}"; ContentEncoding = $null }
+                }
                 Mock Connect-MetasysAccount -ModuleName MetasysRestClient
                 Mock Get-SavedMetasysPassword -ModuleName MetasysRestClient {
                     ConvertTo-SecureString -String "ThePassword" -AsPlainText
@@ -221,7 +231,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             }
 
             It "Should call the operation" {
-                Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Scope Context -Times 1 -Exactly
+                Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Scope Context -Times 1 -Exactly
             }
         }
 
@@ -242,8 +252,8 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             Context "Single body passed in" {
                 It "Should exit BEGIN block and not enter PROCESS block" {
                     Mock Write-Error -ModuleName MetasysRestClient
-                    Mock Invoke-WebRequest -ModuleName MetasysRestClient
-                    Invoke-MetasysMethod /objects -Method Post -Body "body" | Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times  0
+                    Mock invokeHttpRequest -ModuleName MetasysRestClient
+                    Invoke-MetasysMethod /objects -Method Post -Body "body" | Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Exactly -Times  0
 
                 }
             }
@@ -251,8 +261,8 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
                 It "Should exit BEGIN block and not enter PROCESS block" {
 
                     Mock Write-Error -ModuleName MetasysRestClient
-                    Mock Invoke-WebRequest -ModuleName MetasysRestClient
-                    @("body1", "body2") | Invoke-MetasysMethod /objects -Method Post | Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times  0
+                    Mock invokeHttpRequest -ModuleName MetasysRestClient
+                    @("body1", "body2") | Invoke-MetasysMethod /objects -Method Post | Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Exactly -Times  0
                 }
 
             }
@@ -273,7 +283,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
                     Mock Connect-MetasysAccount -ModuleName MetasysRestClient {
                         throw "error"
                     }
-                    Invoke-MetasysMethod /objects -Method Post -Body "body" | Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times  0
+                    Invoke-MetasysMethod /objects -Method Post -Body "body" | Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Exactly -Times  0
 
                 }
             }
@@ -286,7 +296,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
                         throw "error"
                     }
 
-                    @("body1", "body2") | Invoke-MetasysMethod /objects -Method Post | Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times  0
+                    @("body1", "body2") | Invoke-MetasysMethod /objects -Method Post | Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Exactly -Times  0
 
                 }
             }
@@ -304,11 +314,11 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             Context "Multiple bodies passed in and refresh token fails" {
                 It "Should exit BEGIN block and not enter PROCESS block" {
 
-                    Mock Invoke-WebRequest -ModuleName MetasysRestClient
+                    Mock invokeHttpRequest -ModuleName MetasysRestClient
                     Mock Invoke-RestMethod -ModuleName MetasysRestClient {
                         throw "error"
                     }
-                    @("body1", "body2") | Invoke-MetasysMethod /objects -Method Post | Should -Invoke Invoke-WebRequest -ModuleName MetasysRestClient -Exactly -Times  0
+                    @("body1", "body2") | Invoke-MetasysMethod /objects -Method Post | Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Exactly -Times  0
 
                 }
             }
@@ -326,20 +336,20 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
 
         It "Should display response headers and then the response body" {
 
-            $response = @{
-                StatusCode        = 200;
-                StatusDescription = "OK"
-                Headers           = @{
-                    Header1        = "This is header 1";
-                    Header2        = "Header 2";
-                    "Content-Type" = "application/json"
-                };
-                Content           = 123, 10, 32, 32, 34, 105, 116, 101, 109, 34, 58, 32, 123, 10, 32, 32, 32, 32, 34, 112, 114, 101, 115, 101, 110, 116, 86, 97, 108, 117, 101, 34, 58, 32, 55, 50, 46, 53, 10, 32, 32, 125, 10, 125
+            Mock invokeHttpRequest -ModuleName MetasysRestClient {
+                [PSCustomObject]@{
+                    StatusCode        = 200
+                    StatusDescription = "OK"
+                    Headers           = @{
+                        Header1        = "This is header 1"
+                        Header2        = "Header 2"
+                        "Content-Type" = "application/json"
+                    }
+                    Content           = '{"item":{"presentValue":72.5}}'
+                    ContentEncoding   = $null
+                }
             }
-            Mock Invoke-WebRequest -ModuleName MetasysRestClient {
-                # Mocking Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject
-                $response
-            }
+            $expectedBody = '{"item":{"presentValue":72.5}}' | ConvertFrom-Json | ConvertTo-Json -Depth 20 | dos2unix
             $expectedString = @"
 200 (OK)
 Content-Type: application/json
@@ -348,12 +358,78 @@ Header2: Header 2
 
 
 "@ | dos2unix
-            $expectedString += [System.Text.Encoding]::UTF8.GetString($response.Content)
+            $expectedString += $expectedBody
             $actual = Invoke-MetasysMethod /anything -IncludeResponseHeaders | sortHeaders | dos2unix
             $actual | Should -Be  $expectedString
         }
     }
 
+
+    Describe 'When response is binary' {
+        BeforeAll {
+            Clear-MetasysEnvVariables
+            $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
+            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            $env:METASYS_VERSION = $LatestVersion
+            $env:METASYS_HOST = "oas12"
+        }
+
+        Context 'Without -OutFile' {
+            BeforeAll {
+                Mock invokeHttpRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{}
+                        Content           = $null
+                        ContentEncoding   = "br"
+                    }
+                }
+                Mock Write-Warning -ModuleName MetasysRestClient
+                Invoke-MetasysMethod /something
+            }
+
+            It "Should warn the user" {
+                Should -Invoke Write-Warning -ModuleName MetasysRestClient -Times 2 -Exactly -Scope Context
+            }
+
+            It "Should not call invokeHttpRequest more than once" {
+                Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -Times 1 -Exactly -Scope Context
+            }
+        }
+
+        Context 'With -OutFile' {
+            BeforeAll {
+                Mock invokeHttpRequest -ModuleName MetasysRestClient {
+                    [PSCustomObject]@{
+                        StatusCode        = 200
+                        StatusDescription = "OK"
+                        Headers           = @{}
+                        Content           = $null
+                        ContentEncoding   = "br"
+                    }
+                }
+                Mock Write-Warning -ModuleName MetasysRestClient
+                $script:tempFile = [System.IO.Path]::GetTempFileName()
+                Invoke-MetasysMethod /something -OutFile $script:tempFile
+            }
+
+            It "Should pass the resolved output path to invokeHttpRequest" {
+                Should -Invoke invokeHttpRequest -ModuleName MetasysRestClient -ParameterFilter {
+                    $outputFile -eq $script:tempFile
+                } -Times 1 -Exactly -Scope Context
+            }
+
+            It "Should not warn the user" {
+                Should -Invoke Write-Warning -ModuleName MetasysRestClient -Times 0 -Scope Context
+            }
+
+            It "Should output the file path" {
+                $output = Invoke-MetasysMethod /something -OutFile $script:tempFile
+                $output | Should -Be $script:tempFile
+            }
+        }
+    }
 
     Describe 'When -IncludeResponseHeaders with response error' {
         BeforeAll {
@@ -365,19 +441,18 @@ Header2: Header 2
         }
 
         It "Should display all headers and response body" {
-            Mock Invoke-WebRequest -ModuleName MetasysRestClient {
-                # Mocking Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject
-                $response = @{
-                    StatusCode        = 400;
+            Mock invokeHttpRequest -ModuleName MetasysRestClient {
+                [PSCustomObject]@{
+                    StatusCode        = 400
                     StatusDescription = "Bad Request"
                     Headers           = @{
-                        Header1        = "This is header 1";
-                        Header2        = "Header 2";
+                        Header1        = "This is header 1"
+                        Header2        = "Header 2"
                         "Content-Type" = "application/json"
-                    };
-                    Content           = 34, 104, 101, 108, 108, 111, 34
+                    }
+                    Content           = '"hello"'
+                    ContentEncoding   = $null
                 }
-                $response
             }
             $expectedString = @"
 400 (Bad Request)

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -30,24 +30,146 @@ function setBackgroundColorsToMatchConsole {
 
 }
 
-function convertResponseObjectToString {
+
+function invokeHttpRequest {
     param(
-        [WebResponseObject]$responseObject
+        [string]$uri,
+        [string]$method,
+        [string]$body,
+        [string]$token,
+        [switch]$skipCertificateCheck,
+        [hashtable]$headers = @{},
+        [string]$outputFile = ""
     )
 
-    $body = [String]::new($responseObject.Content)
-    $errorMessage = "`nStatus: " + $responseObject.StatusCode.ToString() + " (" + $responseObject.StatusDescription + ")"
-    $responseObject.Headers.Keys | ForEach-Object { $errorMessage += "`n" + $_ + ": " + $responseObject.Headers[$_] }
-    $errorMessage += "`n$body"
-    return $errorMessage
-}
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
+    if ($skipCertificateCheck) {
+        $handler.ServerCertificateCustomValidationCallback = [System.Net.Http.HttpClientHandler]::DangerousAcceptAnyServerCertificateValidator
+    }
+    $httpReq = $null
+    $httpResp = $null
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    try {
+        $client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Bearer $token") | Out-Null
+        foreach ($key in $headers.Keys) {
+            $client.DefaultRequestHeaders.TryAddWithoutValidation($key, $headers[$key]) | Out-Null
+        }
 
-function createErrorStringFromResponseObject {
-    param(
-        [WebResponseObject]$responseObject
-    )
+        $httpMethod = [System.Net.Http.HttpMethod]::new($method.ToUpper())
+        $httpReq = [System.Net.Http.HttpRequestMessage]::new($httpMethod, $uri)
+        if ($body) {
+            $httpReq.Content = [System.Net.Http.StringContent]::new($body, [System.Text.Encoding]::UTF8, "application/json")
+        }
 
-    return convertResponseObjectToString $responseObject
+        # ResponseHeadersRead returns once headers arrive; body is not buffered in memory,
+        # so large payloads do not cause OverflowException.
+        $httpResp = $client.SendAsync($httpReq, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+
+        $statusCode = [int]$httpResp.StatusCode
+        $statusDescription = $httpResp.ReasonPhrase
+
+        $responseHeaders = @{}
+        foreach ($h in $httpResp.Headers) {
+            $responseHeaders[$h.Key] = $h.Value -join ", "
+        }
+        foreach ($h in $httpResp.Content.Headers) {
+            $responseHeaders[$h.Key] = $h.Value -join ", "
+        }
+
+        # AutomaticDecompression strips gzip/deflate from ContentEncoding after handling them.
+        # identity means no encoding. Anything else left (e.g. br, zstd) is unhandled binary.
+        $contentEncoding = @($httpResp.Content.Headers.ContentEncoding | Where-Object { $_ -ne 'identity' })
+        $isBinary = $contentEncoding.Count -gt 0
+
+        # Binary with no output file: return immediately without downloading the body.
+        if ($isBinary -and -not $outputFile) {
+            return [PSCustomObject]@{
+                StatusCode        = $statusCode
+                StatusDescription = $statusDescription
+                Headers           = $responseHeaders
+                Content           = $null
+                ContentEncoding   = $contentEncoding -join ", "
+            }
+        }
+
+        # Content-Length may be absent for chunked transfers.
+        $totalBytes = $httpResp.Content.Headers.ContentLength
+        $stream = $httpResp.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+        $buffer = [byte[]]::new(81920)
+        $totalRead = [long]0
+
+        $reportProgress = {
+            if ($totalBytes -gt 0) {
+                $pct = [int]([Math]::Min(($totalRead / $totalBytes) * 100, 100))
+                Write-Progress -Activity "Downloading" `
+                    -Status "$([int]($totalRead / 1KB)) KB / $([int]($totalBytes / 1KB)) KB" `
+                    -PercentComplete $pct
+            } else {
+                Write-Progress -Activity "Downloading" `
+                    -Status "$([int]($totalRead / 1KB)) KB received" `
+                    -PercentComplete -1
+            }
+        }
+
+        if ($isBinary) {
+            # Stream directly to file — no MemoryStream, no double-allocation.
+            $fileStream = [System.IO.FileStream]::new($outputFile, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+            try {
+                $bytesRead = $stream.Read($buffer, 0, $buffer.Length)
+                while ($bytesRead -gt 0) {
+                    $fileStream.Write($buffer, 0, $bytesRead)
+                    $totalRead += $bytesRead
+                    & $reportProgress
+                    $bytesRead = $stream.Read($buffer, 0, $buffer.Length)
+                }
+            }
+            finally {
+                Write-Progress -Activity "Downloading" -Completed
+                $fileStream.Dispose()
+                $stream.Dispose()
+            }
+            return [PSCustomObject]@{
+                StatusCode        = $statusCode
+                StatusDescription = $statusDescription
+                Headers           = $responseHeaders
+                Content           = $null
+                ContentEncoding   = $contentEncoding -join ", "
+            }
+        }
+
+        # Text/JSON: buffer in MemoryStream.
+        $accumulator = [System.IO.MemoryStream]::new()
+        try {
+            $bytesRead = $stream.Read($buffer, 0, $buffer.Length)
+            while ($bytesRead -gt 0) {
+                $accumulator.Write($buffer, 0, $bytesRead)
+                $totalRead += $bytesRead
+                & $reportProgress
+                $bytesRead = $stream.Read($buffer, 0, $buffer.Length)
+            }
+        }
+        finally {
+            Write-Progress -Activity "Downloading" -Completed
+            $stream.Dispose()
+        }
+
+        $bytes = $accumulator.ToArray()
+        $accumulator.Dispose()
+
+        return [PSCustomObject]@{
+            StatusCode        = $statusCode
+            StatusDescription = $statusDescription
+            Headers           = $responseHeaders
+            Content           = [System.Text.Encoding]::UTF8.GetString($bytes)
+            ContentEncoding   = $null
+        }
+    }
+    finally {
+        if ($null -ne $httpResp) { $httpResp.Dispose() }
+        if ($null -ne $httpReq) { $httpReq.Dispose() }
+        $client.Dispose()
+    }
 }
 
 function invokeWithWarningsOff {
@@ -149,6 +271,11 @@ function Invoke-MetasysMethod {
         # Alias: -rh
         [Alias("rh")]
         [Switch]$IncludeResponseHeaders,
+        # Write the response body to this file path. Use when the response is binary.
+        #
+        # Alias: -of
+        [Alias("of")]
+        [string]$OutFile,
 
         # Add a subscription for this resource. Pass a `stream id` as the value
         # of this parameter. For example `0915342b-4557-401e-a061-237d0bced15d` (
@@ -250,66 +377,71 @@ function Invoke-MetasysMethod {
             $Headers['Metasys-Subscribe'] = $Subscribe
         }
 
-        $request = buildRequest -uri $uri -method $Method -body $Body -token ([MetasysEnvVars]::getToken()) -skipCertificateCheck:$SkipCertificateCheck `
-            -headers $Headers
-
-
         $response = $null
-        $responseObject = $null
 
         Write-Information -Message "Attempting request"
 
+        $resolvedOutputFile = ""
+        if ($OutFile) {
+            $resolvedOutputFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutFile)
+        }
+
+        $result = $null
         try {
-            $responseObject = Invoke-WebRequest @request -SkipHttpErrorCheck
+            $result = invokeHttpRequest -uri $uri.ToString() -method $Method.ToString() -body $Body `
+                -token ([MetasysEnvVars]::getTokenAsPlainText()) -skipCertificateCheck:$SkipCertificateCheck `
+                -headers $Headers -outputFile $resolvedOutputFile
         }
         catch {
-            # Catches errors like host name can't be found but not http errors like 4xx, 5xx due to SkipHttpErrorCheck above
             Write-Error $_
             return
         }
 
-        $contentType = "unknown"; # one of json, text, unknown
-        if ($responseObject) {
-
-            $contentLength = 0
-            if ($responseObject.Headers["Content-Length"]) {
-                [Int]::TryParse($responseObject.Headers["Content-Length"], [ref] $contentLength)  | Out-Null
-            } elseif ($responseObject.Content -is [String]) {
-                $contentLength = $responseObject.Content
+        if ($result -and $result.ContentEncoding) {
+            if ($OutFile) {
+                $resolvedOutputFile
+            } else {
+                Write-Warning "The response is $($result.ContentEncoding)-encoded binary. Use -OutFile to save it, e.g.:"
+                Write-Warning "    imm $Path -OutFile output.bin"
             }
-
-            if ($responseObject.Headers["Content-Type"] -like "*json*" -or $contentLength -eq 0 -or $responseObject.StatusCode -eq 204 -or $responseObject.StatusCode -ge 400) {
-                $contentType = "json"
-            }
-            elseif ($responseObject.Headers["Content-Type"] -like "text*") {
-                $contentType = "text"
-            }
-            else {
-                $contentType = "unknown"
-                Write-Error "An unexpected content type was found"
-                Write-Error (createErrorStringFromResponseObject -responseObject $responseObject)
-
-            }
-            if ($responseObject.Content -is [String]) {
-                $response = $responseObject.Content
-            }
-            else {
-                $response = [System.Text.Encoding]::UTF8.GetString($responseObject.Content)
-            }
+            return
         }
 
-        # Only overwrite the last response if $response is not null
+        $statusCode = $result.StatusCode
+        $statusDescription = $result.StatusDescription
+        $responseHeaders = $result.Headers
+        $response = $result.Content
+
+        $contentType = "unknown" # one of json, text, unknown
+        $contentLength = 0
+        if ($responseHeaders["Content-Length"]) {
+            [Int]::TryParse($responseHeaders["Content-Length"], [ref] $contentLength) | Out-Null
+        } else {
+            $contentLength = if ($null -ne $response) { $response.Length } else { 0 }
+        }
+
+        if ($responseHeaders["Content-Type"] -like "*json*" -or $contentLength -eq 0 -or $statusCode -eq 204 -or $statusCode -ge 400) {
+            $contentType = "json"
+        }
+        elseif ($responseHeaders["Content-Type"] -like "text*") {
+            $contentType = "text"
+        }
+        else {
+            $contentType = "unknown"
+            Write-Warning "Unexpected content type: $($responseHeaders["Content-Type"])"
+        }
+
+        # Only overwrite the last response if content is JSON
         if ($null -ne $response -and $contentType -eq "json") {
             [MetasysEnvVars]::setLast($response)
-            [MetasysEnvVars]::setHeaders($responseObject.Headers)
-            [MetasysEnvVars]::setStatus($responseObject.StatusCode, $responseObject.StatusDescription)
+            [MetasysEnvVars]::setHeaders($responseHeaders)
+            [MetasysEnvVars]::setStatus($statusCode, $statusDescription)
         }
 
         if ($ReturnBodyAsObject.IsPresent -and $null -ne $response -and $contentType -eq "json") {
             Get-LastMetasysResponseBodyAsObject
         }
         elseif ($null -ne $response) {
-
             if ($contentType -eq "json") {
                 if ($IncludeResponseHeaders) {
                     Show-LastMetasysFullResponse
@@ -318,16 +450,17 @@ function Invoke-MetasysMethod {
                     Show-LastMetasysResponseBody
                 }
             }
-            if ($contentType -eq "text") {
-
+            elseif ($contentType -eq "text") {
                 if ($IncludeResponseHeaders) {
-                    $responseObject.RawContent
+                    "$statusCode ($statusDescription)"
+                    $responseHeaders.Keys | ForEach-Object { "$_`: $($responseHeaders[$_])" }
+                    ""
+                    $response
                 }
                 else {
                     $response
                 }
             }
-
         }
     }
 

--- a/src/MetasysRestClient/build-request.ps1
+++ b/src/MetasysRestClient/build-request.ps1
@@ -28,6 +28,10 @@ function buildRequest {
         $request.Authentication = "bearer"
     }
 
+    # Hint to servers that we prefer encodings PowerShell can auto-decompress.
+    # Servers may ignore this and send br or other encodings anyway.
+    $request.Headers["Accept-Encoding"] = "gzip, deflate"
+
     if ($headers) {
         foreach ($header in $Headers.GetEnumerator()) {
             $request.Headers[$header.Key] = $header.Value


### PR DESCRIPTION
`Invoke-WebRequest` buffers the entire response body in memory,
causing an `OverflowException` on large payloads. Replace with
`HttpClient` using `ResponseHeadersRead` so the body is streamed
in chunks rather than buffered. Show a progress bar while
downloading.

Add `-OutFile`/`-of` parameter to `Invoke-MetasysMethod` for
saving large responses to disk and require it for binary content.

Also detect responses with unhandled `Content-Encoding` as
binary. `HttpClientHandler.AutomaticDecompression` strips `gzip`
and `deflate`; anything remaining other than `identity` indicates
content the client cannot decode. When binary content is
detected and `-OutFile` is not given, abort immediately
without downloading the body and warn the user. When
`-OutFile` is given, stream directly to a `FileStream`.

Update all Pester tests to mock the new `invokeHttpRequest`
boundary instead of `Invoke-WebRequest`, and fix
`IncludeResponseHeaders` test mocks to use the new DTO shape.