### PR TITLE
fix: use dedicated temp dir for last response, clean on each write

### DIFF
--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -395,4 +395,23 @@ Header2: Header 2
         }
     }
 
+    Describe 'Show-LastMetasysResponseBody called standalone' {
+
+        BeforeAll {
+            $script:tempFile = New-TemporaryFile
+            Set-Content -Path $script:tempFile.FullName -Value '{"answer":42}'
+            $env:METASYS_LAST_RESPONSE_PATH = $script:tempFile.FullName
+        }
+
+        AfterAll {
+            Remove-Item $script:tempFile.FullName -ErrorAction SilentlyContinue
+            $env:METASYS_LAST_RESPONSE_PATH = $null
+        }
+
+        It "Returns the stored response body as formatted JSON without error" {
+            $result = Show-LastMetasysResponseBody
+            $result | Should -BeLike '*"answer": 42*'
+        }
+    }
+
 }

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -372,7 +372,7 @@ function ConvertFrom-JsonSafely {
 
 function Show-LastMetasysResponseBody {
     $body = [MetasysEnvVars]::getLast()
-    if ($body -and ($contentType -eq "json")) {
+    if ($body) {
         ConvertFrom-JsonSafely $body | ConvertTo-Json -Depth 20
     }
 }

--- a/src/MetasysRestClient/MetasysEnvVars.Tests.ps1
+++ b/src/MetasysRestClient/MetasysEnvVars.Tests.ps1
@@ -1,0 +1,76 @@
+Set-StrictMode -Version 3
+
+# Load at script body level so InModuleScope can find the local version during discovery
+Remove-Module MetasysRestClient -ErrorAction SilentlyContinue
+Import-Module -Name ./ -Force
+
+Describe "MetasysEnvVars.setLast" {
+
+    InModuleScope MetasysRestClient {
+
+        BeforeEach {
+            # Start each test with a clean directory state
+            $dir = [MetasysEnvVars]::getLastResponseDir()
+            if ([System.IO.Directory]::Exists($dir)) {
+                Remove-Item -Path $dir -Recurse -Force
+            }
+            $env:METASYS_LAST_RESPONSE_PATH = $null
+        }
+
+        AfterAll {
+            $dir = [MetasysEnvVars]::getLastResponseDir()
+            if ([System.IO.Directory]::Exists($dir)) {
+                Remove-Item -Path $dir -Recurse -Force
+            }
+            $env:METASYS_LAST_RESPONSE_PATH = $null
+        }
+
+        It "Creates the directory if it does not exist" {
+            [MetasysEnvVars]::setLast('{}')
+            $dir = [MetasysEnvVars]::getLastResponseDir()
+            [System.IO.Directory]::Exists($dir) | Should -BeTrue
+        }
+
+        It "Writes content to the fixed path" {
+            [MetasysEnvVars]::setLast('{"value":1}')
+            $path = [System.IO.Path]::Combine([MetasysEnvVars]::getLastResponseDir(), 'last-response')
+            Get-Content -Path $path -Raw | Should -Be '{"value":1}'
+        }
+
+        It "Sets METASYS_LAST_RESPONSE_PATH to the fixed path" {
+            [MetasysEnvVars]::setLast('{}')
+            $expected = [System.IO.Path]::Combine([MetasysEnvVars]::getLastResponseDir(), 'last-response')
+            $env:METASYS_LAST_RESPONSE_PATH | Should -Be $expected
+        }
+
+        It "Removes leftover files from previous sessions before writing" {
+            $dir = [MetasysEnvVars]::getLastResponseDir()
+            [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+            # Simulate orphaned files from old sessions
+            Set-Content -Path ([System.IO.Path]::Combine($dir, 'old-file-1')) -Value 'stale'
+            Set-Content -Path ([System.IO.Path]::Combine($dir, 'old-file-2')) -Value 'stale'
+
+            [MetasysEnvVars]::setLast('{"fresh":true}')
+
+            $files = @(Get-ChildItem -Path $dir -File)
+            $files | Should -HaveCount 1
+            $files[0].Name | Should -Be 'last-response'
+        }
+
+        It "getLast returns the content written by setLast" {
+            [MetasysEnvVars]::setLast('{"answer":42}')
+            [MetasysEnvVars]::getLast() | Should -BeLike '*"answer":42*'
+        }
+    }
+}
+
+Describe "MetasysEnvVars.clear" {
+
+    It "Clears METASYS_LAST_RESPONSE_PATH" {
+        InModuleScope MetasysRestClient {
+            $env:METASYS_LAST_RESPONSE_PATH = 'some/path'
+            [MetasysEnvVars]::clear()
+            $env:METASYS_LAST_RESPONSE_PATH | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -59,13 +59,21 @@ class MetasysEnvVars {
         return ""
     }
 
+    static [string] getLastResponseDir() {
+        return [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), 'MetasysRestClient')
+    }
+
     static [void] setLast([string]$last) {
-        # This variable used to save the last response to an env var, but that generally can be very large
-        # So now instead we write the response to a temp file and instead of writing to
-        # $env:METASYS_LAST_RESPONSE we write the path of the file to $env:METASYS_LAST_RESPONSE_PATH
-        $tempFile = New-TemporaryFile
-        Set-Content -Path $tempFile.FullName -Value $last
-        $env:METASYS_LAST_RESPONSE_PATH = $tempFile.FullName
+        $dir = [MetasysEnvVars]::getLastResponseDir()
+        # Clean the directory before writing so files from any prior write don't accumulate.
+        if ([System.IO.Directory]::Exists($dir)) {
+            Get-ChildItem -Path $dir -File | Remove-Item -ErrorAction SilentlyContinue
+        } else {
+            [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+        }
+        $path = [System.IO.Path]::Combine($dir, 'last-response')
+        Set-Content -Path $path -Value $last -NoNewline
+        $env:METASYS_LAST_RESPONSE_PATH = $path
     }
 
     static [void] clear() {
@@ -79,6 +87,7 @@ class MetasysEnvVars {
         $env:METASYS_SKIP_CERTIFICATE_CHECK = $null
         $env:METASYS_USER_NAME = $null
         $env:METASYS_VERSION = $null
+        $env:METASYS_LAST_RESPONSE_PATH = $null
     }
 
     static [void] setHeaders([Hashtable]$headers) {


### PR DESCRIPTION
New-TemporaryFile creates a new random file on every call with no
cleanup, accumulating orphaned files across sessions. The previous
env-var approach only cleaned up within the same session.

Replace with a fixed subdirectory ($TMPDIR/MetasysRestClient/) and
fixed filename (last-response). setLast() removes all files in the
directory before writing, cleaning up leftovers from any prior write
regardless of env var state.

Also fix two related bugs found during testing:
- clear() was not nulling METASYS_LAST_RESPONSE_PATH
- Show-LastMetasysResponseBody checked $contentType, a local variable
  from Invoke-MetasysMethod's PROCESS block never in scope when called
  standalone; the check was redundant since only JSON is stored

Add unit tests for setLast, getLastResponseDir, getLast, and clear
(MetasysEnvVars.Tests.psr
Show-LastMetasysResponseBody.

## Test plan
- [x] `Invoke-Pester` (67 tests) passes from `src/MetasysRestClient/`
- [x] After `imm`, `$env:METASYS_LAST_RESPONSE_PATH` points to
      `…/MetasysRestClient/last-response`
- [x] `Show-LastMetasysResponseBody` works when called standalone