### PR TITLE
feat: store access token in module memory instead of env var

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -98,8 +98,8 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 } -Times 1 -Exactly -Scope Context
             }
 
-            It 'Should set $env:METASYS_ACCESS_TOKEN as an encrypted string whose decrypted value matches what we expect' {
-                $env:METASYS_ACCESS_TOKEN | ConvertTo-SecureString | ConvertFrom-SecureString -AsPlainText | Should -Be  $loginResponse.accessToken
+            It 'Should store the access token with value matching what we expect' {
+                InModuleScope MetasysRestClient { [MetasysEnvVars]::getTokenAsPlainText() } | Should -Be $loginResponse.accessToken
             }
 
             It 'Should set $env:METASYS_EXPIRES' {
@@ -219,8 +219,8 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 } -Times 1 -Exactly -Scope Context
             }
 
-            It 'Should set $env:METASYS_ACCESS_TOKEN' {
-                $env:METASYS_ACCESS_TOKEN | ConvertTo-SecureString | ConvertFrom-SecureString -AsPlainText | Should -Be  $loginResponse.accessToken
+            It 'Should store the access token with value matching what we expect' {
+                InModuleScope MetasysRestClient { [MetasysEnvVars]::getTokenAsPlainText() } | Should -Be $loginResponse.accessToken
             }
 
             It 'Should set $env:METASYS_EXPIRES' {

--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -104,7 +104,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
     Describe "When Token Stored in Env Vars and Token is not expired, and SiteHost stored in env vars" {
         BeforeAll {
             Clear-MetasysEnvVariables
-            $env:METASYS_ACCESS_TOKEN = (ConvertTo-SecureString -AsPlainText "This is the token") | ConvertFrom-SecureString
+            InModuleScope MetasysRestClient { [MetasysEnvVars]::setTokenAsPlainText("This is the token") }
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
             $env:METASYS_HOST = "oas12"
         }
@@ -198,7 +198,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
         BeforeAll {
             Clear-MetasysEnvVariables
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow - [TimeSpan]::FromMinutes(5)).ToString("o")
-            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            InModuleScope MetasysRestClient { [MetasysEnvVars]::setTokenAsPlainText("secure token") }
             $env:METASYS_VERSION = $LatestVersion
             $env:METASYS_HOST = "oas12"
             $env:METASYS_USER_NAME = "api"
@@ -273,7 +273,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             BeforeAll {
                 Clear-MetasysEnvVariables
                 $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow - [TimeSpan]::FromMinutes(5)).ToString("o")
-                $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+                InModuleScope MetasysRestClient { [MetasysEnvVars]::setTokenAsPlainText("secure token") }
                 $env:METASYS_VERSION = $LatestVersion
             }
 
@@ -306,7 +306,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
             BeforeAll {
                 Clear-MetasysEnvVariables
                 $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(2)).ToString("o")
-                $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+                InModuleScope MetasysRestClient { [MetasysEnvVars]::setTokenAsPlainText("secure token") }
                 $env:METASYS_VERSION = $LatestVersion
                 $env:METASYS_HOST = "oas12"
             }
@@ -329,7 +329,7 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
         BeforeAll {
             Clear-MetasysEnvVariables
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
-            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            InModuleScope MetasysRestClient { [MetasysEnvVars]::setTokenAsPlainText("secure token") }
             $env:METASYS_VERSION = $LatestVersion
             $env:METASYS_HOST = "oas12"
         }
@@ -369,7 +369,7 @@ Header2: Header 2
         BeforeAll {
             Clear-MetasysEnvVariables
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
-            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            InModuleScope MetasysRestClient { [MetasysEnvVars]::setTokenAsPlainText("secure token") }
             $env:METASYS_VERSION = $LatestVersion
             $env:METASYS_HOST = "oas12"
         }
@@ -435,7 +435,7 @@ Header2: Header 2
         BeforeAll {
             Clear-MetasysEnvVariables
             $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
-            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            InModuleScope MetasysRestClient { [MetasysEnvVars]::setTokenAsPlainText("secure token") }
             $env:METASYS_VERSION = $LatestVersion
             $env:METASYS_HOST = "oas12"
         }

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -469,7 +469,7 @@ function Invoke-MetasysMethod {
 
 
 function Show-LastMetasysAccessToken {
-    ConvertFrom-SecureString -AsPlainText -SecureString ([MetasysEnvVars]::getToken())
+    [MetasysEnvVars]::getToken()
 }
 
 function Show-LastMetasysHeaders {

--- a/src/MetasysRestClient/build-request.ps1
+++ b/src/MetasysRestClient/build-request.ps1
@@ -9,7 +9,7 @@ function buildRequest {
         [Parameter(Mandatory = $true)]
         [string]$uri,
         [string]$body = $null,
-        [SecureString]$token,
+        [string]$token,
         [switch]$skipCertificateCheck,
         [Hashtable]$headers
     )
@@ -24,8 +24,7 @@ function buildRequest {
     }
 
     if ($token) {
-        $request.Token = $token
-        $request.Authentication = "bearer"
+        $request.Headers["Authorization"] = "Bearer $token"
     }
 
     # Hint to servers that we prefer encodings PowerShell can auto-decompress.

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -1,5 +1,7 @@
 Set-StrictMode -Version 3
 class MetasysEnvVars {
+    static hidden [string] $Token = $null
+
     static [string] getSiteHost() {
         return $env:METASYS_HOST
     }
@@ -16,7 +18,7 @@ class MetasysEnvVars {
         $env:METASYS_VERSION = $version
     }
 
-    static [DateTimeOffset] getExpires() {
+    static [object] getExpires() {
         $aDate = [DateTimeOffset]::Now
         if ([DateTimeOffset]::TryParse($env:METASYS_EXPIRES, [ref]$aDate)) {
             return $aDate
@@ -28,28 +30,22 @@ class MetasysEnvVars {
         $env:METASYS_EXPIRES = $expires.ToString("o")
     }
 
-    static [SecureString] getToken() {
-        if ($env:METASYS_ACCESS_TOKEN) {
-            return ConvertTo-SecureString $env:METASYS_ACCESS_TOKEN
-        }
-        return $null
+    static [object] getToken() {
+        $t = [MetasysEnvVars]::Token
+        if ([string]::IsNullOrEmpty($t)) { return $null }
+        return $t
     }
 
-    static [void] setToken([SecureString]$token) {
-        $env:METASYS_ACCESS_TOKEN = ConvertFrom-SecureString -SecureString $token
+    static [void] setToken([string]$token) {
+        [MetasysEnvVars]::Token = $token
     }
 
-    static [String] getTokenAsPlainText() {
-        $secureToken = [MetasysEnvVars]::getToken()
-        if ($secureToken) {
-            return (ConvertFrom-SecureString -SecureString $secureToken -AsPlainText)
-        }
-
-        return $null
+    static [string] getTokenAsPlainText() {
+        return [MetasysEnvVars]::Token
     }
 
-    static [void] setTokenAsPlainText([String]$token) {
-        [MetasysEnvVars]::setToken(($token | ConvertTo-SecureString -AsPlainText))
+    static [void] setTokenAsPlainText([string]$token) {
+        [MetasysEnvVars]::Token = $token
     }
 
     static [string] getLast() {
@@ -77,7 +73,7 @@ class MetasysEnvVars {
     }
 
     static [void] clear() {
-        $env:METASYS_ACCESS_TOKEN = $null
+        [MetasysEnvVars]::Token = $null
         $env:METASYS_EXPIRES = $null
         $env:METASYS_HOST = $null
         $env:METASYS_LAST_HEADERS = $null


### PR DESCRIPTION
## Rationale

On macOS and Linux, `SecureString` provides no encryption — this is documented .NET behavior. Storing the token in `$env:METASYS_ACCESS_TOKEN` also exposes it to child processes and makes it visible in any env dump (`Get-ChildItem Env:`). A module-scoped variable is isolated to the PowerShell process, never written to disk, and not inherited by child processes, giving equivalent protection to tools like `gh` CLI on macOS.

## Impact

`SecureString` is completely eliminated from the codebase. The access token is held in a `static hidden [string] $Token` property on `MetasysEnvVars`, scoped to the running PowerShell process. It no longer appears in env dumps or leaks to child processes.

## Changes

- **`metasys-env-vars.ps1`**: replace `$env:METASYS_ACCESS_TOKEN` with a `static hidden [string] $Token` property; simplify all token methods
- **`build-request.ps1`**: replace `-Token`/`-Authentication bearer` with a plain `Authorization` header, removing the last `SecureString` usage
- **`Invoke-MetasysMethod.psm1`**: simplify `Show-LastMetasysAccessToken`
- **Tests**: wrap `[MetasysEnvVars]` calls in `InModuleScope`; update `Connect-MetasysAccount` assertions to use `getTokenAsPlainText()`
- **Bug fix**: `getToken()` and `getExpires()` declared typed return values that prevented returning `$null`, masking failures when no session exists

## Test plan

- [ ] All 72 existing Pester tests pass (`Invoke-Pester`)
- [ ] `cma` → `imm /objects` works in a real session (token survives across calls)
- [ ] `Show-LastMetasysAccessToken` returns the token after login
- [ ] `Clear-MetasysEnvVariables` resets to no-token state
- [ ] `Get-ChildItem Env:METASYS*` does not show the access token after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)